### PR TITLE
Implement agent skeleton

### DIFF
--- a/agent_core.py
+++ b/agent_core.py
@@ -29,7 +29,9 @@ class Agent:
         self.tools[spec.name] = spec
 
     async def plan(self, user_input: str) -> str:
-        return ""  # Not implemented yet
+        """Return a placeholder response until tools are added."""
+        return "I'm not ready to help yet."
 
     async def execute_plan(self, plan: str) -> str:
-        return ""  # Not implemented yet
+        """Execute a planned sequence of tool calls (stub)."""
+        return ""

--- a/conversation.py
+++ b/conversation.py
@@ -10,11 +10,17 @@ from homeassistant.components.conversation import (
 )
 from homeassistant.helpers import intent
 
+from .agent_core import Agent
+
 _LOGGER = logging.getLogger(__name__)
 
 
 class SpecialAgentConversation(ConversationEntity, AbstractConversationAgent):
     """Minimal conversation agent stub."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.agent = Agent()
 
     @property
     def unique_id(self) -> str:
@@ -41,9 +47,15 @@ class SpecialAgentConversation(ConversationEntity, AbstractConversationAgent):
         return await self.async_process(conversation_input, context)
 
     async def async_process(self, conversation_input, context=None) -> ConversationResult:
+        user_text = getattr(conversation_input, "text", "")
+        result_text = await self.agent.plan(user_text)
+
         response = intent.IntentResponse(language=conversation_input.language)
-        response.async_set_speech("I'm not ready to help yet.")
-        return ConversationResult(conversation_id=conversation_input.conversation_id, response=response)
+        response.async_set_speech(result_text)
+        return ConversationResult(
+            conversation_id=conversation_input.conversation_id,
+            response=response,
+        )
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):

--- a/tests/test_agent_skeleton.py
+++ b/tests/test_agent_skeleton.py
@@ -1,0 +1,13 @@
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from agent_core import Agent
+
+
+def test_agent_plan_returns_placeholder():
+    agent = Agent()
+    response = asyncio.run(agent.plan("Hi"))
+    assert "not ready" in response.lower() or "can't help" in response.lower()


### PR DESCRIPTION
## Summary
- implement a minimal `Agent` placeholder that answers it isn't ready
- wire `SpecialAgentConversation` to use the new agent skeleton
- add smoke test for the skeleton agent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a601e7f18833290cde586dc303ed3