### PR TITLE
Implement phase 1b vector index

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
-from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.config_entries import ConfigEntry
+try:  # during unit tests Home Assistant may not be installed
+    from homeassistant.core import HomeAssistant, ServiceCall
+    from homeassistant.config_entries import ConfigEntry
+except ModuleNotFoundError:  # pragma: no cover - fallback stubs
+    HomeAssistant = object
+    ServiceCall = object
+    ConfigEntry = object
 
 DOMAIN = "special_agent"
 PLATFORMS = ["conversation"]

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,14 @@
     "version": "0.0.1",
     "documentation": "https://example.com",
     "dependencies": ["conversation"],
-    "requirements": ["langchain", "openai", "langchain-community", "numpy", "tiktoken"],
+    "requirements": [
+        "langchain",
+        "openai",
+        "langchain-community",
+        "numpy",
+        "tiktoken",
+        "faiss-cpu"
+    ],
     "codeowners": ["@cliffmu"],
     "config_flow": true
 }

--- a/tests/test_vector_index.py
+++ b/tests/test_vector_index.py
@@ -1,0 +1,19 @@
+import os
+from utils.vector_index import build_vector_index, load_vector_index, query_vector_index
+
+
+def test_build_and_query_vector_index(tmp_path):
+    states = [
+        {"entity_id": "light.kitchen", "name": "Kitchen Light", "attributes": {"friendly_name": "Kitchen Light"}},
+        {"entity_id": "switch.garage", "name": "Garage Switch", "attributes": {"friendly_name": "Garage"}},
+    ]
+    persist = tmp_path / "index"
+    index, docs = build_vector_index(states, persist_dir=str(persist))
+
+    assert os.path.exists(persist / "index.faiss")
+    assert len(docs) == 2
+
+    loaded = load_vector_index(str(persist))
+    results = query_vector_index(loaded, "kitchen", k=2)
+    ids = [r["metadata"]["entity_id"] for r in results]
+    assert "light.kitchen" in ids

--- a/tool_specs/search_devices.py
+++ b/tool_specs/search_devices.py
@@ -1,1 +1,33 @@
-"""Placeholder for search_devices tool."""
+"""Tool for retrieving device entity_ids by similarity search."""
+from __future__ import annotations
+
+from typing import List
+
+import voluptuous as vol
+
+from ..utils.vector_index import load_vector_index, query_vector_index
+from ..agent_core import ToolSpec
+
+
+PARAMS = vol.Schema(
+    {
+        vol.Required("query"): str,
+        vol.Optional("k", default=5): int,
+    }
+)
+
+
+async def search_devices(query: str, k: int = 5) -> List[str]:
+    """Return entity_ids matching the query from the vector index."""
+    index_data = load_vector_index()
+    results = query_vector_index(index_data, query, k)
+    return [doc["metadata"]["entity_id"] for doc in results]
+
+
+SPEC = ToolSpec(
+    name="search_devices",
+    description="Find matching Home Assistant entities by text query.",
+    parameters=PARAMS,
+    returns="list of entity_ids",
+    func=search_devices,
+)

--- a/utils/data_sources.py
+++ b/utils/data_sources.py
@@ -1,1 +1,74 @@
-"""Utility module placeholder."""
+"""Helpers for retrieving Home Assistant data."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, List, Tuple
+
+try:  # Home Assistant may be absent during testing
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import area_registry as ar
+    from homeassistant.helpers import device_registry as dr
+    from homeassistant.helpers import entity_registry as er
+except ModuleNotFoundError:  # pragma: no cover - fallback stubs
+    HomeAssistant = object  # type: ignore
+    ar = dr = er = None  # type: ignore
+
+
+def get_ha_states(hass: HomeAssistant) -> List[Dict]:
+    """Return conversation-exposed states from Home Assistant."""
+    devices: List[Dict] = []
+    for state in hass.states.all():
+        exposed = state.attributes.get("conversation_exposed", True)
+        if exposed:
+            devices.append(
+                {
+                    "entity_id": state.entity_id,
+                    "name": state.name,
+                    "attributes": state.attributes,
+                    "domain": state.domain,
+                }
+            )
+    return devices
+
+
+async def get_devices_by_area(hass: HomeAssistant) -> Tuple[Dict, List[Dict]]:
+    """Return device registry info grouped by area."""
+    area_reg = ar.async_get(hass) if ar else None
+    device_reg = dr.async_get(hass) if dr else None
+    entity_reg = er.async_get(hass) if er else None
+
+    area_map = {area.id: area.name for area in area_reg.areas.values()} if area_reg else {}
+    devices = device_reg.devices if device_reg else {}
+    entities = entity_reg.entities if entity_reg else {}
+
+    device_entities_map = defaultdict(list)
+    for ent in entities.values():
+        if ent.device_id:
+            device_entities_map[ent.device_id].append(ent)
+
+    summary: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    detail: List[Dict] = []
+
+    for device_id, device_entry in devices.items():
+        area_name = area_map.get(device_entry.area_id, "Unassigned")
+
+        domains = {ent.entity_id.split(".")[0] for ent in device_entities_map[device_id]}
+
+        detail.append(
+            {
+                "id": device_id,
+                "name": device_entry.name or f"Device {device_id}",
+                "area": area_name,
+                "domains": list(domains),
+                "manufacturer": device_entry.manufacturer,
+                "model": device_entry.model,
+            }
+        )
+
+        for domain in domains:
+            summary[area_name][domain] += 1
+
+    summary = {area: dict(domains) for area, domains in summary.items()}
+    return summary, detail
+

--- a/utils/vector_index.py
+++ b/utils/vector_index.py
@@ -1,1 +1,95 @@
-"""Utility module placeholder."""
+"""Simple FAISS-based vector index for Home Assistant devices."""
+from __future__ import annotations
+
+import json
+import os
+from typing import Iterable, Tuple, List, Dict
+
+import faiss
+import numpy as np
+
+
+DIMENSION = 128
+
+
+def _text_to_vector(text: str, dim: int = DIMENSION) -> np.ndarray:
+    """Hash words into a fixed-size vector."""
+    vec = np.zeros(dim, dtype=np.float32)
+    for word in text.split():
+        idx = hash(word) % dim
+        vec[idx] += 1.0
+    return vec
+
+
+def build_vector_index(
+    states: Iterable[Dict],
+    persist_dir: str = "vector_index",
+    force_rebuild: bool = False,
+) -> Tuple[faiss.Index, List[Dict]]:
+    """Build or load a FAISS index from Home Assistant states."""
+    os.makedirs(persist_dir, exist_ok=True)
+    index_file = os.path.join(persist_dir, "index.faiss")
+    mapping_file = os.path.join(persist_dir, "mapping.json")
+
+    if not force_rebuild and os.path.exists(index_file) and os.path.exists(mapping_file):
+        try:
+            index = faiss.read_index(index_file)
+            with open(mapping_file, "r", encoding="utf-8") as f:
+                mapping = json.load(f)
+            return index, mapping
+        except Exception:
+            pass  # fallthrough to rebuild
+
+    docs = []
+    vectors = []
+    for st in states:
+        text = (
+            f"Entity: {st.get('entity_id')}\n"
+            f"Name: {st.get('name')}\n"
+            f"Attributes: {st.get('attributes')}"
+        )
+        vec = _text_to_vector(text)
+        docs.append({"page_content": text, "metadata": {"entity_id": st.get("entity_id")}})
+        vectors.append(vec)
+
+    if not vectors:
+        raise ValueError("No states provided to build vector index")
+
+    matrix = np.vstack(vectors).astype("float32")
+    index = faiss.IndexFlatL2(matrix.shape[1])
+    index.add(matrix)
+
+    faiss.write_index(index, index_file)
+    with open(mapping_file, "w", encoding="utf-8") as f:
+        json.dump(docs, f, indent=2)
+
+    return index, docs
+
+
+def load_vector_index(persist_dir: str = "vector_index") -> Tuple[faiss.Index, List[Dict]] | Tuple[None, None]:
+    """Load a previously built FAISS index if available."""
+    index_file = os.path.join(persist_dir, "index.faiss")
+    mapping_file = os.path.join(persist_dir, "mapping.json")
+    if os.path.exists(index_file) and os.path.exists(mapping_file):
+        try:
+            index = faiss.read_index(index_file)
+            with open(mapping_file, "r", encoding="utf-8") as f:
+                mapping = json.load(f)
+            return index, mapping
+        except Exception:
+            return None, None
+    return None, None
+
+
+def query_vector_index(index_data: Tuple[faiss.Index, List[Dict]], query: str, k: int = 5) -> List[Dict]:
+    """Query the FAISS index and return matching docs."""
+    if not index_data or index_data[0] is None:
+        return []
+    index, docs = index_data
+    vec = _text_to_vector(query)
+    distances, indices = index.search(np.array([vec], dtype="float32"), k)
+    results = []
+    for idx in indices[0]:
+        if 0 <= idx < len(docs):
+            results.append(docs[idx])
+    return results


### PR DESCRIPTION
## Summary
- implement FAISS-based vector index utilities
- add search_devices tool using the new index
- fall back when Home Assistant imports are missing
- include faiss-cpu requirement
- test vector index build and query
- expose helpers for pulling Home Assistant data into the index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ba7e21ba08332bb6519a5a7b9d095