### PR TITLE
Replace faiss with numpy index

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,8 +9,7 @@
         "openai",
         "langchain-community",
         "numpy",
-        "tiktoken",
-        "faiss-cpu"
+        "tiktoken"
     ],
     "codeowners": ["@cliffmu"],
     "config_flow": true

--- a/migration_to_agent_plan.md
+++ b/migration_to_agent_plan.md
@@ -90,7 +90,7 @@ class ToolSpec:
 Heuristic unchanged; o3‑pro pricing: $20 /M in, $80 /M out vs $2 / $8 for o3‑mini :contentReference[oaicite:5]{index=5}.
 
 ### 3.3 Entity retrieval & vector indexes  
-Global + per‑area FAISS sub‑indexes; auto‑refresh via `build_vector_index` :contentReference[oaicite:6]{index=6}.
+Global + per‑area NumPy sub‑indexes; auto‑refresh via `build_vector_index` :contentReference[oaicite:6]{index=6}.
 
 ---
 
@@ -100,12 +100,12 @@ Global + per‑area FAISS sub‑indexes; auto‑refresh via `build_vector_index`
 |------|------|--------|-----|-----|---------|
 | 1 | `control_device` | `service,data` | `hass.services.async_call` | — | `"OK"` |
 | 2 | `confirm_action` | `action,targets` | formats question | **mini** (<50 tok) | text |
-| 3 | `search_devices` | `query,area?,k` | FAISS cosine search | — | `[entity_id]` |
+| 3 | `search_devices` | `query,area?,k` | NumPy cosine search | — | `[entity_id]` |
 | 4 | `generate_scene` | `intent,area` | compose commands; optional `scene.create` :contentReference[oaicite:7]{index=7} | — | `commands_list` |
 | 5 | `area_iterator` | `intent` | loop areas, dedupe | — | `commands_list` |
 | 6 | `learn_preferences` ★ | `area,entity_id,prefs,mode` | merge or overwrite JSON | — | `"saved"` |
 | 7 | `preference_manager` | `user,area,key,mode` | JSON get/set | — | value |
-| 8 | `build_vector_index` | `{force?:bool}` | rebuild FAISS | — | `"rebuilt"` |
+| 8 | `build_vector_index` | `{force?:bool}` | rebuild index | — | `"rebuilt"` |
 | 9 | `ask_user` | `question` | store pending session | — | question |
 |10 | `get_weather` | `location?` | sensor + API | **mini** (<100 tok) | forecast |
 |11 | `search_spotify` | `query,type` | Spotify `/search` :contentReference[oaicite:8]{index=8} | — | URI |
@@ -156,7 +156,7 @@ RULES:
 | ----- | ----------- | ------------------ |
 | 0 | **Repo bootstrap** | ✅ HACS loads component :contentReference[oaicite:2]{index=2} |
 | 1 | **Agent skeleton** (no tools) | ✅ “Hi” → “can’t help yet” |
-| 1b | **`build_vector_index` (foundational)** – pull HA states, chunk, embed, write global FAISS index | ✅ index file exists; `search_devices` returns results |
+| 1b | **`build_vector_index` (foundational)** – pull HA states, chunk, embed, write global NumPy index | ✅ index file exists; `search_devices` returns results |
 | 2 | **Control MVP** (`search_devices`, `control_device`, `confirm_action`) | → test *kitchen light* |
 | 2b | **Nightly index refresh** (CLI cron calling `build_vector_index --force`) | → “rebuild database” |
 | 3 | **Info tools** (`get_weather`, `search_spotify`) | → spoken weather query |
@@ -235,7 +235,7 @@ Routing keeps monthly cost ≈ $4 for 500 control + 100 scene requests. :conte
 4. Recorder integration (history API) – https://www.home-assistant.io/integrations/recorder/ :contentReference[oaicite:13]{index=13}  
 5. OpenAI structured outputs – https://platform.openai.com/docs/api-reference/responses/create :contentReference[oaicite:14]{index=14}  
 6. OpenAI o3‑pro pricing – https://community.openai.com/t/o3-is-80-cheaper-and-introducing-o3-pro/1284925 :contentReference[oaicite:15]{index=15}  
-7. Medium guide on FAISS metadata filtering – https://medium.com/@dmitri.mahayana/ultimate-semantics-search-part-2-metadata-filtering-05cad97bc5da :contentReference[oaicite:16]{index=16}  
+7. Medium guide on metadata filtering – https://medium.com/@dmitri.mahayana/ultimate-semantics-search-part-2-metadata-filtering-05cad97bc5da :contentReference[oaicite:16]{index=16}
 8. Spotify Web API search – https://developer.spotify.com/documentation/web-api/reference/search :contentReference[oaicite:17]{index=17}  
 9. Home Assistant scenes docs – https://www.home-assistant.io/docs/scene/ :contentReference[oaicite:18]{index=18}  
 10. Voluptuous validation library – https://pypi.org/project/voluptuous/ :contentReference[oaicite:19]{index=19}  

--- a/tests/test_vector_index.py
+++ b/tests/test_vector_index.py
@@ -10,7 +10,7 @@ def test_build_and_query_vector_index(tmp_path):
     persist = tmp_path / "index"
     index, docs = build_vector_index(states, persist_dir=str(persist))
 
-    assert os.path.exists(persist / "index.faiss")
+    assert os.path.exists(persist / "matrix.npy")
     assert len(docs) == 2
 
     loaded = load_vector_index(str(persist))

--- a/utils/vector_index.py
+++ b/utils/vector_index.py
@@ -1,11 +1,10 @@
-"""Simple FAISS-based vector index for Home Assistant devices."""
+"""Simple NumPy-based vector index for Home Assistant devices."""
 from __future__ import annotations
 
 import json
 import os
 from typing import Iterable, Tuple, List, Dict
 
-import faiss
 import numpy as np
 
 
@@ -25,18 +24,18 @@ def build_vector_index(
     states: Iterable[Dict],
     persist_dir: str = "vector_index",
     force_rebuild: bool = False,
-) -> Tuple[faiss.Index, List[Dict]]:
-    """Build or load a FAISS index from Home Assistant states."""
+) -> Tuple[np.ndarray, List[Dict]]:
+    """Build or load a NumPy index from Home Assistant states."""
     os.makedirs(persist_dir, exist_ok=True)
-    index_file = os.path.join(persist_dir, "index.faiss")
+    index_file = os.path.join(persist_dir, "matrix.npy")
     mapping_file = os.path.join(persist_dir, "mapping.json")
 
     if not force_rebuild and os.path.exists(index_file) and os.path.exists(mapping_file):
         try:
-            index = faiss.read_index(index_file)
+            matrix = np.load(index_file)
             with open(mapping_file, "r", encoding="utf-8") as f:
                 mapping = json.load(f)
-            return index, mapping
+            return matrix, mapping
         except Exception:
             pass  # fallthrough to rebuild
 
@@ -56,40 +55,36 @@ def build_vector_index(
         raise ValueError("No states provided to build vector index")
 
     matrix = np.vstack(vectors).astype("float32")
-    index = faiss.IndexFlatL2(matrix.shape[1])
-    index.add(matrix)
-
-    faiss.write_index(index, index_file)
+    np.save(index_file, matrix)
     with open(mapping_file, "w", encoding="utf-8") as f:
         json.dump(docs, f, indent=2)
 
-    return index, docs
+    return matrix, docs
 
 
-def load_vector_index(persist_dir: str = "vector_index") -> Tuple[faiss.Index, List[Dict]] | Tuple[None, None]:
-    """Load a previously built FAISS index if available."""
-    index_file = os.path.join(persist_dir, "index.faiss")
+def load_vector_index(persist_dir: str = "vector_index") -> Tuple[np.ndarray, List[Dict]] | Tuple[None, None]:
+    """Load a previously built NumPy index if available."""
+    index_file = os.path.join(persist_dir, "matrix.npy")
     mapping_file = os.path.join(persist_dir, "mapping.json")
     if os.path.exists(index_file) and os.path.exists(mapping_file):
         try:
-            index = faiss.read_index(index_file)
+            matrix = np.load(index_file)
             with open(mapping_file, "r", encoding="utf-8") as f:
                 mapping = json.load(f)
-            return index, mapping
+            return matrix, mapping
         except Exception:
             return None, None
     return None, None
 
 
-def query_vector_index(index_data: Tuple[faiss.Index, List[Dict]], query: str, k: int = 5) -> List[Dict]:
-    """Query the FAISS index and return matching docs."""
+def query_vector_index(index_data: Tuple[np.ndarray, List[Dict]], query: str, k: int = 5) -> List[Dict]:
+    """Query the index and return matching docs using cosine similarity."""
     if not index_data or index_data[0] is None:
         return []
-    index, docs = index_data
+    matrix, docs = index_data
     vec = _text_to_vector(query)
-    distances, indices = index.search(np.array([vec], dtype="float32"), k)
-    results = []
-    for idx in indices[0]:
-        if 0 <= idx < len(docs):
-            results.append(docs[idx])
-    return results
+    matrix_norm = matrix / (np.linalg.norm(matrix, axis=1, keepdims=True) + 1e-9)
+    vec_norm = vec / (np.linalg.norm(vec) + 1e-9)
+    scores = matrix_norm @ vec_norm
+    top_indices = scores.argsort()[::-1][:k]
+    return [docs[i] for i in top_indices]


### PR DESCRIPTION
## Summary
- remove `faiss-cpu` from manifest requirements
- rewrite vector_index utilities to use NumPy instead of FAISS
- update tests for NumPy-based index
- adjust migration plan to mention NumPy approach

## Testing
- `pip install voluptuous numpy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bb7ef32408332b052f5878f8e4609