### PR TITLE
Update logging and index path

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 try:  # during unit tests Home Assistant may not be installed
     from homeassistant.core import HomeAssistant, ServiceCall
     from homeassistant.config_entries import ConfigEntry
@@ -12,6 +14,8 @@ except ModuleNotFoundError:  # pragma: no cover - fallback stubs
 
 DOMAIN = "special_agent"
 PLATFORMS = ["conversation"]
+
+_LOGGER = logging.getLogger(__package__)
 
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
@@ -28,6 +32,11 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Special Agent from a config entry."""
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry.data
+    if entry.options.get("debug_logging"):
+        _LOGGER.setLevel(logging.DEBUG)
+        _LOGGER.debug("Debug logging enabled")
+    else:
+        _LOGGER.setLevel(logging.INFO)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 

--- a/config_flow.py
+++ b/config_flow.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from homeassistant import config_entries
 from homeassistant.core import callback
+import voluptuous as vol
 
 from . import DOMAIN
 
@@ -37,4 +38,13 @@ class SpecialAgentOptionsFlow(config_entries.OptionsFlow):
     async def async_step_init(self, user_input: dict[str, Any] | None = None):
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
-        return self.async_show_form(step_id="init")
+
+        schema = vol.Schema(
+            {
+                vol.Optional(
+                    "debug_logging",
+                    default=self.config_entry.options.get("debug_logging", False),
+                ): bool
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=schema)

--- a/conversation.py
+++ b/conversation.py
@@ -12,7 +12,7 @@ from homeassistant.helpers import intent
 
 from .agent_core import Agent
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__package__)
 
 
 class SpecialAgentConversation(ConversationEntity, AbstractConversationAgent):

--- a/migration_to_agent_plan.md
+++ b/migration_to_agent_plan.md
@@ -89,8 +89,8 @@ class ToolSpec:
 ### 3.2 Cost‑aware model routing  
 Heuristic unchanged; o3‑pro pricing: $20 /M in, $80 /M out vs $2 / $8 for o3‑mini :contentReference[oaicite:5]{index=5}.
 
-### 3.3 Entity retrieval & vector indexes  
-Global + per‑area NumPy sub‑indexes; auto‑refresh via `build_vector_index` :contentReference[oaicite:6]{index=6}.
+### 3.3 Entity retrieval & vector indexes
+Global + per‑area NumPy sub‑indexes stored in the integration's `data` folder; auto‑refresh via `build_vector_index` :contentReference[oaicite:6]{index=6}.
 
 ---
 
@@ -156,7 +156,7 @@ RULES:
 | ----- | ----------- | ------------------ |
 | 0 | **Repo bootstrap** | ✅ HACS loads component :contentReference[oaicite:2]{index=2} |
 | 1 | **Agent skeleton** (no tools) | ✅ “Hi” → “can’t help yet” |
-| 1b | **`build_vector_index` (foundational)** – pull HA states, chunk, embed, write global NumPy index | ✅ index file exists; `search_devices` returns results |
+| 1b | **`build_vector_index` (foundational)** – pull HA states, chunk, embed, write global NumPy index under `data/vector_index/` | ✅ index file exists; `search_devices` returns results |
 | 2 | **Control MVP** (`search_devices`, `control_device`, `confirm_action`) | → test *kitchen light* |
 | 2b | **Nightly index refresh** (CLI cron calling `build_vector_index --force`) | → “rebuild database” |
 | 3 | **Info tools** (`get_weather`, `search_spotify`) | → spoken weather query |
@@ -166,7 +166,7 @@ RULES:
 | 4c | **`area_iterator`** | → whole‑home “good night” |
 | 5 | **ReAct loop** – stream tool outputs back to LLM | → complex multi‑step |
 | 5b | **o3‑pro router** – cost‑aware model switch | → long prompt selects pro |
-| 5c | **Per‑area sub‑index build** (`vector_index/<area>/`) | → per‑area latency < 150 ms |
+| 5c | **Per‑area sub‑index build** (`data/vector_index/<area>/`) | → per‑area latency < 150 ms |
 | 5d | **`learn_preferences`** + session detector | → last tweak persisted |
 | 6 | **Safety & multi‑device dedupe** (3‑iteration cap) | → two speakers parallel |
 | 7 | **Test harness** (`pytest‑homeassistant`) | → all unit tests pass :contentReference[oaicite:3]{index=3} |
@@ -206,7 +206,7 @@ RULES:
 ```
 
 ```jsonc
-// vector_index/living_room/index_meta.json
+// data/vector_index/living_room/index_meta.json
 {
   "area_id": "living_room",
   "created": "2025‑06‑13T10:00Z",

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -1,1 +1,11 @@
-"""Utility module placeholder."""
+"""Integration-wide constants."""
+
+from __future__ import annotations
+
+import os
+
+
+PACKAGE_DIR = os.path.dirname(os.path.dirname(__file__))
+DATA_DIR = os.path.join(PACKAGE_DIR, "data")
+VECTOR_INDEX_DIR = os.path.join(DATA_DIR, "vector_index")
+

--- a/utils/vector_index.py
+++ b/utils/vector_index.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 
 import json
 import os
+import logging
 from typing import Iterable, Tuple, List, Dict
+
+from .constants import VECTOR_INDEX_DIR
+
+_LOGGER = logging.getLogger(__package__)
 
 import numpy as np
 
@@ -22,11 +27,12 @@ def _text_to_vector(text: str, dim: int = DIMENSION) -> np.ndarray:
 
 def build_vector_index(
     states: Iterable[Dict],
-    persist_dir: str = "vector_index",
+    persist_dir: str = VECTOR_INDEX_DIR,
     force_rebuild: bool = False,
 ) -> Tuple[np.ndarray, List[Dict]]:
     """Build or load a NumPy index from Home Assistant states."""
     os.makedirs(persist_dir, exist_ok=True)
+    _LOGGER.debug("Building vector index in %s", persist_dir)
     index_file = os.path.join(persist_dir, "matrix.npy")
     mapping_file = os.path.join(persist_dir, "mapping.json")
 
@@ -59,10 +65,12 @@ def build_vector_index(
     with open(mapping_file, "w", encoding="utf-8") as f:
         json.dump(docs, f, indent=2)
 
+    _LOGGER.info("Vector index built with %d entries", len(docs))
+
     return matrix, docs
 
 
-def load_vector_index(persist_dir: str = "vector_index") -> Tuple[np.ndarray, List[Dict]] | Tuple[None, None]:
+def load_vector_index(persist_dir: str = VECTOR_INDEX_DIR) -> Tuple[np.ndarray, List[Dict]] | Tuple[None, None]:
     """Load a previously built NumPy index if available."""
     index_file = os.path.join(persist_dir, "matrix.npy")
     mapping_file = os.path.join(persist_dir, "mapping.json")
@@ -71,8 +79,10 @@ def load_vector_index(persist_dir: str = "vector_index") -> Tuple[np.ndarray, Li
             matrix = np.load(index_file)
             with open(mapping_file, "r", encoding="utf-8") as f:
                 mapping = json.load(f)
+            _LOGGER.debug("Loaded vector index from %s", persist_dir)
             return matrix, mapping
         except Exception:
+            _LOGGER.warning("Failed to load vector index from %s", persist_dir)
             return None, None
     return None, None
 


### PR DESCRIPTION
## Summary
- move vector index storage under `data/`
- centralize constants for data paths
- write index build/load debug messages
- add debug logging option in config flow
- switch logs to use package logger
- document data folder use in migration plan

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bd1c9c0b48332a1a59b545b6ccc56