### PR TITLE
Fix import path for utils and add test fixture

### DIFF
--- a/agent_core.py
+++ b/agent_core.py
@@ -13,7 +13,10 @@ except ModuleNotFoundError:  # pragma: no cover - fallback stub
 
 import voluptuous as vol
 
-from utils import data_sources
+try:
+    from .utils import data_sources
+except ImportError:  # pragma: no cover - support running as script
+    from utils import data_sources  # type: ignore
 
 _LOGGER = logging.getLogger("custom_components.special_agent")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+@pytest.fixture
+def hass():
+    """Provide a stub hass instance for tests requiring it."""
+    return None


### PR DESCRIPTION
## Summary
- fix module import for utils to support both package and direct execution
- add a simple `hass` fixture for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d0a38af5083328e3911ab1d4a8502