### PR TITLE
Implement build_vector_index tool & micro-ReAct improvements

### DIFF
--- a/agent_core.py
+++ b/agent_core.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Dict
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+import inspect
 
 import voluptuous as vol
 
@@ -27,17 +28,99 @@ class Agent:
     def __init__(self) -> None:
         _LOGGER.debug("Agent Init")
         self.tools: Dict[str, ToolSpec] = {}
+        self.load_tools()
+
+    def load_tools(self) -> None:
+        """Register built-in tools from tool_specs package."""
+        try:
+            from .tool_specs.search_devices import SPEC as SEARCH_SPEC
+            from .tool_specs.build_vector_index import SPEC as BUILD_SPEC
+        except Exception as err:  # pragma: no cover - optional tools
+            _LOGGER.error("Failed loading tool specs: %s", err)
+            return
+        self.register_tool(SEARCH_SPEC)
+        self.register_tool(BUILD_SPEC)
 
     def register_tool(self, spec: ToolSpec) -> None:
         _LOGGER.debug("Agent Register Tool")
         self.tools[spec.name] = spec
 
-    async def plan(self, user_input: str) -> str:
-        """Return a placeholder response until tools are added."""
+    async def plan(self, user_input: str, hass: Any | None = None) -> str:
+        """Plan and execute a response using available tools."""
         _LOGGER.debug("Agent Plan")
-        return "I'm not ready to help yet."
+        try:
+            return await plan_execute(user_input, list(self.tools.values()), hass=hass)
+        except RuntimeError as err:
+            _LOGGER.error("Planning failed: %s", err)
+            return "I'm not ready to help yet."
 
-    async def execute_plan(self, plan: str) -> str:
-        _LOGGER.debug("Agent Execute Plan")
-        """Execute a planned sequence of tool calls (stub)."""
-        return ""
+
+def _spec_to_json(spec: ToolSpec) -> Dict:
+    """Convert ToolSpec to OpenAI JSON schema."""
+    props = {k: {"type": "string"} for k in spec.parameters.schema.keys()}
+    return {
+        "type": "function",
+        "function": {
+            "name": spec.name,
+            "description": spec.description,
+            "parameters": {"type": "object", "properties": props},
+        },
+    }
+
+
+async def plan_execute(
+    prompt: str,
+    tools: List[ToolSpec],
+    hass: Optional[Any] = None,
+    model: str = "o3-mini",
+) -> str:
+    """Simple ReAct loop using OpenAI function calling."""
+    try:
+        import openai
+    except ModuleNotFoundError:  # pragma: no cover - openai optional
+        raise RuntimeError("openai package not available")
+
+    tool_json = [_spec_to_json(t) for t in tools]
+    system_prompt = (
+        "You are Special\u00a0Agent, a smart-home AI.\n" "TOOLS:\n" + str(tool_json)
+        + "\nWhen you need to perform an external action, respond with:\n"
+        "{\n \"tool_calls\": [{ \"name\": \"<tool>\", \"arguments\": { ... } }] }\n"
+        "Otherwise, reply directly to the user."
+    )
+
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": prompt},
+    ]
+    depth = 0
+    while depth < 3:
+        resp = await openai.ChatCompletion.acreate(
+            model=model,
+            messages=messages,
+            tools=tool_json,
+            tool_choice="auto",
+            stream=False,
+        )
+        message = resp.choices[0].message
+        if message.content:
+            _LOGGER.debug("Thought: %s", message.content)
+        if not message.tool_calls and not (message.content or "").strip():
+            raise RuntimeError("assistant returned empty message")
+
+        if message.tool_calls:
+            call = message.tool_calls[0]
+            spec_map = {t.name: t for t in tools}
+            func = spec_map[call.name].func
+            args = spec_map[call.name].parameters(call.arguments)
+            _LOGGER.debug("Action: %s %s", call.name, call.arguments)
+            if hass is not None and "hass" in inspect.signature(func).parameters:
+                result = await func(hass=hass, **args)
+            else:
+                result = await func(**args)
+            _LOGGER.debug("Observation: %s", result)
+            messages.append({"role": "assistant", **message})
+            messages.append({"role": "tool", "name": call.name, "content": result})
+            depth += 1
+            continue
+        return message.content or ""
+    return "Depth limit reached"

--- a/conversation.py
+++ b/conversation.py
@@ -48,7 +48,7 @@ class SpecialAgentConversation(ConversationEntity, AbstractConversationAgent):
 
     async def async_process(self, conversation_input, context=None) -> ConversationResult:
         user_text = getattr(conversation_input, "text", "")
-        result_text = await self.agent.plan(user_text)
+        result_text = await self.agent.plan(user_text, hass=self.hass)
 
         response = intent.IntentResponse(language=conversation_input.language)
         response.async_set_speech(result_text)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+import os
+from unittest.mock import MagicMock
+
+os.environ.setdefault('SPECIAL_AGENT_TESTING', 'true')
+
+import sys
+sys.modules.setdefault('homeassistant', MagicMock())
+sys.modules.setdefault('homeassistant.core', MagicMock())
+sys.modules.setdefault('homeassistant.helpers', MagicMock())
+sys.modules.setdefault('homeassistant.helpers.intent', MagicMock())
+
+import pytest
+
+@pytest.fixture
+def hass():
+    return MagicMock()

--- a/tests/test_build_vector_index_tool.py
+++ b/tests/test_build_vector_index_tool.py
@@ -1,0 +1,40 @@
+import asyncio
+import os
+import sys
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from special_agent.tool_specs.build_vector_index import build_vector_index_tool
+
+
+def test_build_vector_index_tool_uses_datasource(monkeypatch):
+    hass = MagicMock()
+    sample_states = [
+        {"entity_id": "light.kitchen", "name": "Kitchen Light", "attributes": {}},
+        {"entity_id": "switch.garage", "name": "Garage Switch", "attributes": {}},
+    ]
+
+    called = {}
+
+    def fake_get_states(hass_arg):
+        called["get"] = True
+        assert hass_arg is hass
+        return sample_states
+
+    def fake_build(states, force_rebuild=False):
+        called["build"] = states
+        return None, states
+
+    monkeypatch.setattr(
+        "special_agent.tool_specs.build_vector_index.get_ha_states", fake_get_states
+    )
+    monkeypatch.setattr(
+        "special_agent.tool_specs.build_vector_index.build_vector_index", fake_build
+    )
+
+    result = asyncio.run(build_vector_index_tool(hass=hass))
+
+    assert result == "rebuilt"
+    assert called["get"]
+    assert called["build"] == sample_states

--- a/tool_specs/build_vector_index.py
+++ b/tool_specs/build_vector_index.py
@@ -1,0 +1,35 @@
+"""Tool to rebuild the vector index from Home Assistant states."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterable, Dict
+
+import voluptuous as vol
+
+from ..utils import logging as log
+from ..utils.vector_index import build_vector_index
+from ..utils.data_sources import get_ha_states
+from ..agent_core import ToolSpec
+
+_LOGGER = logging.getLogger(__package__)
+
+PARAMS = vol.Schema({vol.Optional("force", default=False): bool})
+
+
+async def build_vector_index_tool(
+    force: bool = False,
+    hass: Any | None = None,
+) -> str:
+    """Build or refresh the vector index from Home Assistant states."""
+    states = get_ha_states(hass) if hass else []
+    build_vector_index(states, force_rebuild=force)
+    log.info("Vector index built with %d states", len(states))
+    return "rebuilt"
+
+SPEC = ToolSpec(
+    name="build_vector_index",
+    description="Rebuild the smart-home vector index from HA states.",
+    parameters=PARAMS,
+    returns="rebuilt",
+    func=build_vector_index_tool,
+)


### PR DESCRIPTION
## Summary
- fetch states in `build_vector_index_tool` using data sources
- add a test covering the new tool behavior
- integrate micro-ReAct loop into `Agent.plan`
- allow passing `hass` through the conversation entity

## Testing
- `pip install voluptuous numpy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d1534515c83329c95d3344e76de01