### PR TITLE
Add OpenAI API key configuration

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 
 _LOGGER = logging.getLogger(__package__)
 
@@ -32,6 +33,9 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Special Agent from a config entry."""
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry.data
+    api_key = entry.options.get("openai_api_key") or entry.data.get("openai_api_key")
+    if api_key and not os.environ.get("OPENAI_API_KEY"):
+        os.environ["OPENAI_API_KEY"] = api_key
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 

--- a/config_flow.py
+++ b/config_flow.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from homeassistant import config_entries
 from homeassistant.core import callback
+import voluptuous as vol
 
 from . import DOMAIN
 
@@ -20,9 +21,12 @@ class SpecialAgentConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             await self.async_set_unique_id(DOMAIN)
             self._abort_if_unique_id_configured()
-            return self.async_create_entry(title="Special Agent", data={})
+            return self.async_create_entry(title="Special Agent", data=user_input)
 
-        return self.async_show_form(step_id="user")
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema({vol.Required("openai_api_key"): str}),
+        )
 
     @staticmethod
     @callback
@@ -40,4 +44,17 @@ class SpecialAgentOptionsFlow(config_entries.OptionsFlow):
     async def async_step_init(self, user_input: dict[str, Any] | None = None):
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
-        return self.async_show_form(step_id="init")
+
+        current = dict(self.config_entry.options)
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    "openai_api_key",
+                    default=current.get(
+                        "openai_api_key",
+                        self.config_entry.data.get("openai_api_key", ""),
+                    ),
+                ): str
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=schema)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,16 @@
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock, AsyncMock
+
+import pytest
+
+from special_agent.__init__ import async_setup_entry
+
+
+def test_setup_entry_sets_env(monkeypatch):
+    hass = MagicMock()
+    hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    entry = SimpleNamespace(entry_id="1", data={"openai_api_key": "key"}, options={})
+    asyncio.run(async_setup_entry(hass, entry))
+    assert os.environ.get("OPENAI_API_KEY") == "key"


### PR DESCRIPTION
## Summary
- request an OpenAI API key during setup and in options
- store key in environment variable when integration loads
- add a test to verify the env var is set

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d2b2395b883328b6f33c012d22aff