### PR TITLE
Fix OptionsFlow init

### DIFF
--- a/config_flow.py
+++ b/config_flow.py
@@ -39,7 +39,8 @@ class SpecialAgentOptionsFlow(config_entries.OptionsFlow):
     """Handle options for Special Agent."""
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        super().__init__(config_entry)
+        self.config_entry = config_entry
+        super().__init__()
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None):
         if user_input is not None:


### PR DESCRIPTION
## Summary
- store the ConfigEntry in the options flow
- call base initializer without args

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d2ca10f8c8332bf1a0cb17f3def4c