### PR TITLE
Improve logging utility robustness

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,6 +1,6 @@
 import logging
 
-from utils import logging as log
+import utils.logging as log
 
 
 def test_info_log_level(hass, caplog):
@@ -13,3 +13,16 @@ def test_debug_toggle(hass, caplog):
     caplog.set_level(logging.DEBUG)
     log.debug("Verbose")
     assert "Verbose" in caplog.text
+
+
+def test_debug_handles_format_errors(hass, caplog):
+    caplog.set_level(logging.DEBUG)
+    log.debug("Missing placeholder:", {"foo": 1})
+    assert "Missing placeholder:" in caplog.text
+    assert "'foo': 1" in caplog.text
+
+
+def test_debug_wrong_arg_count(hass, caplog):
+    caplog.set_level(logging.DEBUG)
+    log.debug("Two %s %s", "onlyone")
+    assert "Two" in caplog.text

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -1,14 +1,34 @@
 import logging
+from typing import Any, Tuple
 
 _LOGGER = logging.getLogger(__package__)
 
-def info(msg: str, *args):
-    _LOGGER.info(msg, *args)
+
+def _format(msg: str, args: Tuple[Any, ...]) -> str:
+    """Safely format logging messages.
+
+    Attempts standard %-style formatting. If that fails due to mismatched
+    arguments, fall back to joining the string representation of each
+    argument. This avoids ``logging`` errors when objects contain odd
+    types or when the placeholder count is wrong.
+    """
+
+    if not args:
+        return msg
+
+    try:
+        return msg % args
+    except Exception:
+        return " ".join([msg, *(repr(a) for a in args)])
 
 
-def debug(msg: str, *args):
-    _LOGGER.debug(msg, *args)
+def info(msg: str, *args: Any) -> None:
+    _LOGGER.info(_format(msg, args))
 
 
-def warning(msg: str, *args):
-    _LOGGER.warning(msg, *args)
+def debug(msg: str, *args: Any) -> None:
+    _LOGGER.debug(_format(msg, args))
+
+
+def warning(msg: str, *args: Any) -> None:
+    _LOGGER.warning(_format(msg, args))


### PR DESCRIPTION
## Summary
- make logging wrappers handle bad format strings gracefully
- adjust logging tests to import the custom module correctly
- add tests for bad placeholders and argument counts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e0f734d3c83329adc0549b3561ec4