### PR TITLE
Fix relative import of utils

### DIFF
--- a/agent_core.py
+++ b/agent_core.py
@@ -9,7 +9,10 @@ import os
 
 import voluptuous as vol
 
-from utils import logging as log
+try:
+    from .utils import logging as log
+except ImportError:  # pragma: no cover - support direct execution
+    from utils import logging as log
 
 # ----------  data classes ----------
 @dataclass


### PR DESCRIPTION
## Summary
- fix import path for logging utils to work inside Home Assistant

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'voluptuous')*

------
https://chatgpt.com/codex/tasks/task_e_684e17320cf48332a6557c5739427537