### PR TITLE
Fix OpenAI client creation

### DIFF
--- a/agent_core.py
+++ b/agent_core.py
@@ -84,12 +84,13 @@ async def plan_execute(
 ) -> str:
     if not os.environ.get("OPENAI_API_KEY"):
         return "Sorry, I'm not ready to help yet."
+
     try:
-        from openai import AsyncOpenAI  # ≥ 1.2
-        client = AsyncOpenAI()
-    except Exception:
-        import openai  # legacy
-        client = openai
+        from .utils.openai_client import get_async_client
+        client = await get_async_client(hass)
+    except Exception as err:  # pragma: no cover - openai optional
+        log.error("OpenAI client init failed: %s", err)
+        return "Error initializing OpenAI client"
 
     tool_json = [_spec_to_json(t) for t in tools]
     system_prompt = (


### PR DESCRIPTION
## Summary
- use `get_async_client` helper when creating the OpenAI client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e42be74b88332b6c78fc47866532c