### PR TITLE
Fix custom logging logger name

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,3 +1,3 @@
-import logging
+from logging import getLogger
 
-_LOGGER = logging.getLogger(__package__)
+_LOGGER = getLogger(__package__)


### PR DESCRIPTION
## Summary
- restore `utils.logging` logger name to `custom_components.special_agent`
- stop leaking stdlib `logging` as `utils.logging`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e45daf4cc8332be65b9be65f1a0ee