### PR TITLE
Fix bool parameter type for tools

### DIFF
--- a/agent_core.py
+++ b/agent_core.py
@@ -66,8 +66,14 @@ def _spec_to_json(spec: ToolSpec) -> Dict:
     """Translate Voluptuous schema → JSON schema for OpenAI."""
     props = {}
     for key, validator in spec.parameters.schema.items():
-        # crude but effective: map basic python types to JSON‑Schema 'type'
-        py_type = getattr(validator, "type", str)
+        # crudely map Python/voluptuous validators to JSON Schema types
+        py_type = None
+        if isinstance(validator, type):
+            py_type = validator
+        else:
+            py_type = getattr(validator, "type", None)
+        if py_type is None:
+            py_type = str
         props[str(key)] = {"type": _JSON_TYPES.get(py_type, "string")}
     return {
         "type": "function",

--- a/tests/test_spec_json_conversion.py
+++ b/tests/test_spec_json_conversion.py
@@ -1,0 +1,28 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import voluptuous as vol
+from agent_core import _spec_to_json, ToolSpec
+
+
+async def dummy_func(force: bool = False):
+    return "done"
+
+
+SPEC = ToolSpec(
+    name="build_vector_index",
+    description="Rebuild index",
+    parameters=vol.Schema({vol.Optional("force", default=False): bool}),
+    returns="done",
+    func=dummy_func,
+)
+
+
+def test_bool_parameter_serialized_as_boolean():
+    js = _spec_to_json(SPEC)
+    assert (
+        js["function"]["parameters"]["properties"]["force"]["type"] == "boolean"
+    )
+
+


### PR DESCRIPTION
## Summary
- ensure boolean schema types are reflected correctly in the JSON tool specs
- test `_spec_to_json` conversion for bool parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e509b700483328951d09740e45fe8