### PR TITLE
Fix build_vector_index tool args

### DIFF
--- a/agent_core.py
+++ b/agent_core.py
@@ -149,9 +149,10 @@ async def plan_execute(
             log.debug("Observation: %s", result)
 
             # feed back
+            msg_data = msg.model_dump() if hasattr(msg, "model_dump") else msg.dict()
             messages.extend(
                 [
-                    {"role": "assistant", **msg},
+                    {"role": "assistant", **msg_data},
                     {"role": "tool", "name": call.name, "content": str(result)},
                 ]
             )

--- a/tests/test_build_vector_index_tool.py
+++ b/tests/test_build_vector_index_tool.py
@@ -23,7 +23,7 @@ def test_build_vector_index_tool_uses_datasource(monkeypatch):
         return sample_states
 
     def fake_build(states, force_rebuild=False):
-        called["build"] = states
+        called["build"] = (states, force_rebuild)
         return None, states
 
     monkeypatch.setattr(
@@ -42,4 +42,34 @@ def test_build_vector_index_tool_uses_datasource(monkeypatch):
 
     assert result == "rebuild scheduled"
     assert called["get"]
-    assert called["build"] == sample_states
+    assert called["build"] == (sample_states, False)
+
+
+def test_build_vector_index_tool_force(monkeypatch):
+    hass = MagicMock()
+    sample_states = []
+    called = {}
+
+    def fake_get_states(hass_arg):
+        return sample_states
+
+    def fake_build(states, force_rebuild=False):
+        called["force"] = force_rebuild
+        return None, states
+
+    monkeypatch.setattr(
+        "special_agent.tool_specs.build_vector_index.get_ha_states", fake_get_states
+    )
+    monkeypatch.setattr(
+        "special_agent.tool_specs.build_vector_index.build_vector_index", fake_build
+    )
+
+    async def run_tool():
+        res = await build_vector_index_tool(force=True, hass=hass)
+        await asyncio.sleep(0)
+        return res
+
+    result = asyncio.run(run_tool())
+
+    assert result == "rebuild scheduled"
+    assert called["force"] is True

--- a/tool_specs/build_vector_index.py
+++ b/tool_specs/build_vector_index.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any
 
 import asyncio
+import functools
 
 import voluptuous as vol
 
@@ -30,12 +31,15 @@ async def build_vector_index_tool(
         if callable(add_job) and add_job.__class__.__name__ != "MagicMock":
             states = await add_job(get_ha_states, hass)
             log.debug("Retrieved %d states from Home Assistant", len(states))
-            await add_job(build_vector_index, states, force)
+            await add_job(
+                functools.partial(build_vector_index, force_rebuild=force), states
+            )
         else:
             states = get_ha_states(hass)
             log.debug("Retrieved %d states from Home Assistant", len(states))
             await asyncio.get_running_loop().run_in_executor(
-                None, build_vector_index, states, force
+                None,
+                functools.partial(build_vector_index, states, force_rebuild=force),
             )
         log.info("Vector index built with %d states", len(states))
         log.debug("build_vector_index_tool completed")


### PR DESCRIPTION
## Summary
- fix kwarg handling when building vector index
- handle OpenAI message objects correctly
- test that build_vector_index tool forwards force flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e5876b0f483329915f9edb9a82d60