### PR TITLE
feat(search): filter + re-rank to prioritise actionable devices

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,17 @@
 import os
 from unittest.mock import MagicMock
 
-os.environ.setdefault('SPECIAL_AGENT_TESTING', 'true')
+import pytest
+
+os.environ.setdefault("SPECIAL_AGENT_TESTING", "true")
 
 import sys
-sys.modules.setdefault('homeassistant', MagicMock())
-sys.modules.setdefault('homeassistant.core', MagicMock())
-sys.modules.setdefault('homeassistant.helpers', MagicMock())
-sys.modules.setdefault('homeassistant.helpers.intent', MagicMock())
 
-import pytest
+sys.modules.setdefault("homeassistant", MagicMock())
+sys.modules.setdefault("homeassistant.core", MagicMock())
+sys.modules.setdefault("homeassistant.helpers", MagicMock())
+sys.modules.setdefault("homeassistant.helpers.intent", MagicMock())
+
 
 @pytest.fixture
 def hass():

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -3,8 +3,6 @@ import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock, AsyncMock
 
-import pytest
-
 from special_agent.__init__ import async_setup_entry
 
 

--- a/tests/test_search_device_filter.py
+++ b/tests/test_search_device_filter.py
@@ -1,0 +1,39 @@
+import asyncio
+import importlib
+
+from special_agent.utils.vector_index import build_vector_index
+
+
+def test_search_device_filter(tmp_path, monkeypatch):
+    states = [
+        {
+            "entity_id": "light.office_sconces",
+            "name": "Office Sconces",
+            "attributes": {"friendly_name": "Office Sconces"},
+            "domain": "light",
+        },
+        {
+            "entity_id": "sensor.office_sconces_led_effect",
+            "name": "LED Effect",
+            "attributes": {"friendly_name": "Office LED"},
+            "domain": "sensor",
+        },
+    ]
+
+    persist = tmp_path / "index"
+    build_vector_index(states, persist_dir=str(persist))
+
+    monkeypatch.setenv("SPECIAL_AGENT_PERSIST_DIR", str(persist))
+    import special_agent.utils.vector_index as vi
+    import special_agent.tool_specs.search_devices as sd
+
+    importlib.reload(vi)
+    importlib.reload(sd)
+
+    async def run_search():
+        return await sd.search_devices("turn on the office light", k=5)
+
+    results = asyncio.run(run_search())
+
+    assert "light.office_sconces" in results
+    assert all("sensor.office_sconces_led_effect" != r for r in results)

--- a/tests/test_vector_meta.py
+++ b/tests/test_vector_meta.py
@@ -1,0 +1,28 @@
+import json
+
+from special_agent.utils.vector_index import build_vector_index
+
+
+def test_vector_meta(tmp_path):
+    states = [
+        {
+            "entity_id": "light.kitchen",
+            "name": "Kitchen",
+            "attributes": {},
+            "domain": "light",
+        },
+        {
+            "entity_id": "sensor.kitchen_temperature",
+            "name": "Temp",
+            "attributes": {},
+            "domain": "sensor",
+        },
+    ]
+
+    persist = tmp_path / "index"
+    build_vector_index(states, persist_dir=str(persist))
+
+    with open(persist / "meta.json", encoding="utf-8") as f:
+        meta = json.load(f)
+
+    assert meta.get("excluded_count", 0) > 0

--- a/tool_specs/search_devices.py
+++ b/tool_specs/search_devices.py
@@ -1,4 +1,5 @@
 """Tool for retrieving device entity_ids by similarity search."""
+
 from __future__ import annotations
 
 import logging
@@ -7,6 +8,7 @@ from typing import List
 import voluptuous as vol
 
 from ..utils import logging as log
+from ..utils.constants import EXCLUDED_DOMAINS, PREFERRED_DOMAINS, LOCATION_WORDS
 from ..utils.vector_index import load_vector_index, query_vector_index
 from ..agent_core import ToolSpec
 
@@ -24,9 +26,31 @@ PARAMS = vol.Schema(
 async def search_devices(query: str, k: int = 5) -> List[str]:
     """Return entity_ids matching the query from the vector index."""
     index_data = load_vector_index()
-    results = query_vector_index(index_data, query, k)
-    log.debug("Device search '%s' => %s", query, [d["metadata"]["entity_id"] for d in results])
-    return [doc["metadata"]["entity_id"] for doc in results]
+    raw_results = query_vector_index(index_data, query, k, return_scores=True)
+
+    tokens = set(query.lower().split())
+    scored = []
+    for doc, score in raw_results:
+        entity_id = doc["metadata"].get("entity_id", "")
+        domain = entity_id.split(".")[0]
+        if domain in PREFERRED_DOMAINS:
+            score += 0.25
+        if domain in EXCLUDED_DOMAINS:
+            score -= 0.20
+
+        friendly = (doc["metadata"].get("friendly_name") or "").lower()
+        area = (doc["metadata"].get("area_id") or "").lower()
+        if any(
+            word in LOCATION_WORDS and (word in friendly or word in area)
+            for word in tokens
+        ):
+            score += 0.05
+
+        scored.append((score, entity_id))
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+    log.debug("Device search '%s' => %s", query, [e for _, e in scored])
+    return [e for _, e in scored]
 
 
 SPEC = ToolSpec(

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -1,5 +1,32 @@
-"""Utility module placeholder."""
+"""Shared constants for device filtering and ranking."""
 
-import logging
+EXCLUDED_DOMAINS = {
+    "sensor",
+    "binary_sensor",
+    "update",
+    "number",
+    "select",
+    "button",
+    "event",
+}
 
-_LOGGER = logging.getLogger(__package__)
+PREFERRED_DOMAINS = {
+    "light",
+    "fan",
+    "media_player",
+    "climate",
+    "switch",
+    "cover",
+}
+
+LOCATION_WORDS = {
+    "kitchen",
+    "office",
+    "bedroom",
+    "living",
+    "bath",
+    "foyer",
+    "garage",
+}
+
+EXCLUDED_SUFFIXES = ("_led", "_powertype", "_internaltemperature")

--- a/utils/data_sources.py
+++ b/utils/data_sources.py
@@ -15,8 +15,9 @@ except ModuleNotFoundError:  # pragma: no cover - fallback stubs
     HomeAssistant = object  # type: ignore
     ar = dr = er = None  # type: ignore
 
-_LOGGER = logging.getLogger(__package__)
 from . import logging as log
+
+_LOGGER = logging.getLogger(__package__)
 
 
 def get_ha_states(hass: HomeAssistant) -> List[Dict]:
@@ -52,7 +53,9 @@ async def get_devices_by_area(hass: HomeAssistant) -> Tuple[Dict, List[Dict]]:
         bool(entity_reg),
     )
 
-    area_map = {area.id: area.name for area in area_reg.areas.values()} if area_reg else {}
+    area_map = (
+        {area.id: area.name for area in area_reg.areas.values()} if area_reg else {}
+    )
     devices = device_reg.devices if device_reg else {}
     entities = entity_reg.entities if entity_reg else {}
 
@@ -67,7 +70,9 @@ async def get_devices_by_area(hass: HomeAssistant) -> Tuple[Dict, List[Dict]]:
     for device_id, device_entry in devices.items():
         area_name = area_map.get(device_entry.area_id, "Unassigned")
 
-        domains = {ent.entity_id.split(".")[0] for ent in device_entities_map[device_id]}
+        domains = {
+            ent.entity_id.split(".")[0] for ent in device_entities_map[device_id]
+        }
 
         detail.append(
             {
@@ -86,4 +91,3 @@ async def get_devices_by_area(hass: HomeAssistant) -> Tuple[Dict, List[Dict]]:
     summary = {area: dict(domains) for area, domains in summary.items()}
     log.debug("get_devices_by_area: returning %d device details", len(detail))
     return summary, detail
-

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -13,28 +13,41 @@
 # def warning(msg: str, *args):
 #     _LOGGER.warning(msg, *args)
 
-import logging, re
+import logging
+import re
+
 _LOGGER = logging.getLogger("custom_components.special_agent")
 _PLACEHOLDER_RE = re.compile(r"%\([^)]+\)|%[sdifr]")
 
+
 def _safe(level, msg, *args, **kw):
     if args:
-        try:                      # 1️⃣ classic %-style happy path
+        try:  # 1️⃣ classic %-style happy path
             if _PLACEHOLDER_RE.search(msg):
                 _LOGGER.log(level, msg, *args, **kw)
                 return
             # 2️⃣ brace‑style ?  configure a Formatter(style='{') once
-            if '{' in msg and '}' in msg:
+            if "{" in msg and "}" in msg:
                 _LOGGER.log(level, msg.format(*args), **kw)
                 return
             # 3️⃣ no placeholders → just append repr()s
             msg = f"{msg} " + " ".join(repr(a) for a in args)
-        except Exception:         # paranoia; never crash caller
+        except Exception:  # paranoia; never crash caller
             msg = f"{msg} " + " ".join(repr(a) for a in args)
     _LOGGER.log(level, msg, **kw)
 
-def debug(msg, *args, **kw):   _safe(logging.DEBUG,    msg, *args, **kw)
-def info(msg,  *args, **kw):   _safe(logging.INFO,     msg, *args, **kw)
-def warning(msg,*args, **kw):  _safe(logging.WARNING,  msg, *args, **kw)
-def error(msg, *args, **kw):   _safe(logging.ERROR,    msg, *args, **kw)
 
+def debug(msg, *args, **kw):
+    _safe(logging.DEBUG, msg, *args, **kw)
+
+
+def info(msg, *args, **kw):
+    _safe(logging.INFO, msg, *args, **kw)
+
+
+def warning(msg, *args, **kw):
+    _safe(logging.WARNING, msg, *args, **kw)
+
+
+def error(msg, *args, **kw):
+    _safe(logging.ERROR, msg, *args, **kw)

--- a/utils/vector_index.py
+++ b/utils/vector_index.py
@@ -1,4 +1,5 @@
 """Simple NumPy-based vector index for Home Assistant devices."""
+
 from __future__ import annotations
 
 import logging
@@ -10,11 +11,16 @@ from typing import Iterable, Tuple, List, Dict
 import numpy as np
 
 from . import logging as log
+from .constants import EXCLUDED_DOMAINS, EXCLUDED_SUFFIXES
 
 BASE_DIR = Path(
     os.environ.get(
         "SPECIAL_AGENT_BASE_DIR",
-        "/homeassistant" if Path("/homeassistant").exists() else str(Path(__file__).resolve().parents[2]),
+        (
+            "/homeassistant"
+            if Path("/homeassistant").exists()
+            else str(Path(__file__).resolve().parents[2])
+        ),
     )
 )
 DEFAULT_PERSIST_DIR = os.environ.get(
@@ -55,7 +61,11 @@ def build_vector_index(
     index_file = os.path.join(persist_dir, "matrix.npy")
     mapping_file = os.path.join(persist_dir, "mapping.json")
 
-    if not force_rebuild and os.path.exists(index_file) and os.path.exists(mapping_file):
+    if (
+        not force_rebuild
+        and os.path.exists(index_file)
+        and os.path.exists(mapping_file)
+    ):
         try:
             log.debug("Loading existing index from %s", persist_dir)
             matrix = np.load(index_file)
@@ -69,15 +79,27 @@ def build_vector_index(
 
     docs = []
     vectors = []
+    excluded_count = 0
     for st in states:
-        # log.debug("Vectorizing state %s", st.get("entity_id"))
+        entity_id = st.get("entity_id", "")
+        domain = st.get("domain") or entity_id.split(".")[0]
+        if domain in EXCLUDED_DOMAINS or entity_id.endswith(EXCLUDED_SUFFIXES):
+            excluded_count += 1
+            continue
+
         text = (
-            f"Entity: {st.get('entity_id')}\n"
+            f"Entity: {entity_id}\n"
             f"Name: {st.get('name')}\n"
             f"Attributes: {st.get('attributes')}"
         )
         vec = _text_to_vector(text)
-        docs.append({"page_content": text, "metadata": {"entity_id": st.get("entity_id")}})
+        meta = {
+            "entity_id": entity_id,
+            "friendly_name": st.get("attributes", {}).get("friendly_name"),
+            "area_id": st.get("attributes", {}).get("area_id"),
+            "domain": domain,
+        }
+        docs.append({"page_content": text, "metadata": meta})
         vectors.append(vec)
 
     if not vectors:
@@ -90,13 +112,21 @@ def build_vector_index(
     log.debug("Writing mapping to %s", mapping_file)
     with open(mapping_file, "w", encoding="utf-8") as f:
         json.dump(docs, f, indent=2)
+    meta_file = os.path.join(persist_dir, "meta.json")
+    log.debug("Writing meta to %s", meta_file)
+    with open(meta_file, "w", encoding="utf-8") as f:
+        json.dump({"excluded_count": excluded_count}, f)
 
-    log.info("Vector index rebuilt with %d docs", len(docs))
+    log.info(
+        "Vector index rebuilt with %d docs (excluded=%d)", len(docs), excluded_count
+    )
     log.debug("build_vector_index: completed")
     return matrix, docs
 
 
-def load_vector_index(persist_dir: str = DEFAULT_PERSIST_DIR) -> Tuple[np.ndarray, List[Dict]] | Tuple[None, None]:
+def load_vector_index(
+    persist_dir: str = DEFAULT_PERSIST_DIR,
+) -> Tuple[np.ndarray, List[Dict]] | Tuple[None, None]:
     """Load a previously built NumPy index if available."""
     index_file = os.path.join(persist_dir, "matrix.npy")
     mapping_file = os.path.join(persist_dir, "mapping.json")
@@ -115,7 +145,12 @@ def load_vector_index(persist_dir: str = DEFAULT_PERSIST_DIR) -> Tuple[np.ndarra
     return None, None
 
 
-def query_vector_index(index_data: Tuple[np.ndarray, List[Dict]], query: str, k: int = 5) -> List[Dict]:
+def query_vector_index(
+    index_data: Tuple[np.ndarray, List[Dict]],
+    query: str,
+    k: int = 5,
+    return_scores: bool = False,
+) -> List[Dict] | List[Tuple[Dict, float]]:
     """Query the index and return matching docs using cosine similarity."""
     if not index_data or index_data[0] is None:
         log.debug("query_vector_index: no index data")
@@ -127,6 +162,19 @@ def query_vector_index(index_data: Tuple[np.ndarray, List[Dict]], query: str, k:
     vec_norm = vec / (np.linalg.norm(vec) + 1e-9)
     scores = matrix_norm @ vec_norm
     top_indices = scores.argsort()[::-1][:k]
-    results = [docs[i] for i in top_indices]
-    log.debug("Vector search results: %s", [r["metadata"]["entity_id"] for r in results])
+    if return_scores:
+        results = [(docs[i], float(scores[i])) for i in top_indices]
+    else:
+        results = [docs[i] for i in top_indices]
+    log.debug(
+        "Vector search results: %s",
+        [
+            (
+                r[0]["metadata"]["entity_id"]
+                if return_scores
+                else r["metadata"]["entity_id"]
+            )
+            for r in results
+        ],
+    )
     return results


### PR DESCRIPTION
## Summary
- filter sensors from vector index and keep excluded count meta
- prefer actionable domains when searching
- tweak config flow tests and fixtures for ruff
- add tests for device filtering and meta info

## Testing
- `ruff check . --extend-exclude REFERENCE`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e75fdd36c833296b5e5354b8f1b2b