### PR TITLE
Fix area_id in vector index

### DIFF
--- a/tests/test_vector_index.py
+++ b/tests/test_vector_index.py
@@ -17,3 +17,19 @@ def test_build_and_query_vector_index(tmp_path):
     results = query_vector_index(loaded, "kitchen", k=2)
     ids = [r["metadata"]["entity_id"] for r in results]
     assert "light.kitchen" in ids
+
+
+def test_build_vector_index_includes_area(tmp_path):
+    states = [
+        {
+            "entity_id": "light.bedroom",
+            "name": "Bedroom Light",
+            "attributes": {"friendly_name": "Bedroom Light"},
+            "area_id": "bedroom",
+        }
+    ]
+
+    persist = tmp_path / "index_area"
+    _, docs = build_vector_index(states, persist_dir=str(persist))
+
+    assert docs[0]["metadata"].get("area_id") == "bedroom"

--- a/utils/data_sources.py
+++ b/utils/data_sources.py
@@ -21,21 +21,43 @@ _LOGGER = logging.getLogger(__package__)
 
 
 def get_ha_states(hass: HomeAssistant) -> List[Dict]:
-    """Return conversation-exposed states from Home Assistant."""
+    """Return conversation-exposed states from Home Assistant.
+
+    In addition to the basic state info, this function attempts to
+    resolve the ``area_id`` for each entity via the entity and device
+    registries.  When running tests or if the registries are not
+    available, ``area_id`` will be ``None``.
+    """
     log.debug("get_ha_states: fetching states")
+
+    # Registries may be unavailable when running unit tests
+    entity_reg = er.async_get(hass) if er else None
+    device_reg = dr.async_get(hass) if dr else None
+
     devices: List[Dict] = []
     for state in hass.states.all():
         exposed = state.attributes.get("conversation_exposed", True)
-        # log.debug("State %s exposed=%s", state.entity_id, exposed)
-        if exposed:
-            devices.append(
-                {
-                    "entity_id": state.entity_id,
-                    "name": state.name,
-                    "attributes": state.attributes,
-                    "domain": state.domain,
-                }
-            )
+        if not exposed:
+            continue
+
+        area_id = None
+        if entity_reg and device_reg:
+            ent_entry = entity_reg.entities.get(state.entity_id)
+            if ent_entry and ent_entry.device_id:
+                dev_entry = device_reg.devices.get(ent_entry.device_id)
+                if dev_entry:
+                    area_id = dev_entry.area_id
+
+        devices.append(
+            {
+                "entity_id": state.entity_id,
+                "name": state.name,
+                "attributes": state.attributes,
+                "domain": state.domain,
+                "area_id": area_id,
+            }
+        )
+
     log.debug("get_ha_states: returning %d states", len(devices))
     return devices
 

--- a/utils/vector_index.py
+++ b/utils/vector_index.py
@@ -96,7 +96,9 @@ def build_vector_index(
         meta = {
             "entity_id": entity_id,
             "friendly_name": st.get("attributes", {}).get("friendly_name"),
-            "area_id": st.get("attributes", {}).get("area_id"),
+            # Prefer top-level area_id injected by get_ha_states; fall back to
+            # any value stored under attributes for backward compatibility.
+            "area_id": st.get("area_id") or st.get("attributes", {}).get("area_id"),
             "domain": domain,
         }
         docs.append({"page_content": text, "metadata": meta})


### PR DESCRIPTION
## Summary
- add area lookup to `get_ha_states`
- store area_id in vector index metadata
- test that area_id is captured when provided

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f9f7237a88332a620b2ea82d4d973