### PR TITLE
Add area/domain metadata to vector index docs

### DIFF
--- a/tests/test_vector_index.py
+++ b/tests/test_vector_index.py
@@ -1,4 +1,5 @@
 import os
+import json
 from utils.vector_index import build_vector_index, load_vector_index, query_vector_index
 
 
@@ -33,3 +34,30 @@ def test_build_vector_index_includes_area(tmp_path):
     _, docs = build_vector_index(states, persist_dir=str(persist))
 
     assert docs[0]["metadata"].get("area_id") == "bedroom"
+
+
+def test_mapping_contains_light_area(tmp_path):
+    states = [
+        {
+            "entity_id": "light.kitchen_ceiling",
+            "name": "Kitchen Ceiling",
+            "attributes": {"friendly_name": "Kitchen Ceiling"},
+            "area_id": "kitchen",
+        },
+        {
+            "entity_id": "switch.outlet",
+            "name": "Outlet",
+            "attributes": {"friendly_name": "Outlet"},
+        },
+    ]
+
+    persist = tmp_path / "index_check"
+    build_vector_index(states, persist_dir=str(persist))
+
+    with open(persist / "mapping.json", encoding="utf-8") as f:
+        mapping = json.load(f)
+
+    assert any(
+        doc["metadata"].get("domain") == "light" and doc["metadata"].get("area_id")
+        for doc in mapping
+    )

--- a/tool_specs/build_vector_index.py
+++ b/tool_specs/build_vector_index.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 
 from ..utils import logging as log
 from ..utils.vector_index import build_vector_index
-from ..utils.data_sources import get_ha_states
+from ..utils.data_sources import get_ha_states, enrich_states_metadata
 from ..agent_core import ToolSpec
 
 _LOGGER = logging.getLogger(__package__)
@@ -30,12 +30,14 @@ async def build_vector_index_tool(
         add_job = getattr(hass, "async_add_executor_job", None) if hass else None
         if callable(add_job) and add_job.__class__.__name__ != "MagicMock":
             states = await add_job(get_ha_states, hass)
+            states = enrich_states_metadata(hass, states)
             log.debug("Retrieved %d states from Home Assistant", len(states))
             await add_job(
                 functools.partial(build_vector_index, force_rebuild=force), states
             )
         else:
             states = get_ha_states(hass)
+            states = enrich_states_metadata(hass, states)
             log.debug("Retrieved %d states from Home Assistant", len(states))
             await asyncio.get_running_loop().run_in_executor(
                 None,

--- a/utils/data_sources.py
+++ b/utils/data_sources.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from typing import Dict, List, Tuple
+from typing import Any, Dict, Iterable, List, Tuple
 
 try:  # Home Assistant may be absent during testing
     from homeassistant.core import HomeAssistant
@@ -60,6 +60,54 @@ def get_ha_states(hass: HomeAssistant) -> List[Dict]:
 
     log.debug("get_ha_states: returning %d states", len(devices))
     return devices
+
+
+def resolve_entity_metadata(
+    hass: HomeAssistant, entity_id: str
+) -> Tuple[str | None, str | None]:
+    """Return ``(area_id, friendly_name)`` for an entity via registries."""
+    area_id = None
+    friendly_name = None
+
+    try:
+        state = hass.states.get(entity_id)
+    except Exception:  # pragma: no cover - mocked hass may lack .states
+        state = None
+
+    entity_reg = er.async_get(hass) if er else None
+    device_reg = dr.async_get(hass) if dr else None
+
+    if entity_reg:
+        ent_entry = entity_reg.entities.get(entity_id)
+        if ent_entry:
+            friendly_name = getattr(ent_entry, "original_name", None) or getattr(
+                ent_entry, "name", None
+            )
+            if ent_entry.device_id and device_reg:
+                dev_entry = device_reg.devices.get(ent_entry.device_id)
+                if dev_entry:
+                    area_id = dev_entry.area_id
+
+    if area_id is None and state is not None:
+        area_id = state.attributes.get("area_id")
+    if friendly_name is None and state is not None:
+        friendly_name = state.attributes.get("friendly_name") or state.name
+
+    return area_id, friendly_name
+
+
+def enrich_states_metadata(hass: HomeAssistant, states: Iterable[Dict]) -> List[Dict]:
+    """Update a list of state dicts in place with area_id and friendly name."""
+    result = []
+    for st in states:
+        area_id, friendly = resolve_entity_metadata(hass, st.get("entity_id", ""))
+        if area_id is not None:
+            st["area_id"] = area_id
+        if friendly and isinstance(st.get("attributes"), dict):
+            st.setdefault("attributes", {})
+            st["attributes"].setdefault("friendly_name", friendly)
+        result.append(st)
+    return result
 
 
 async def get_devices_by_area(hass: HomeAssistant) -> Tuple[Dict, List[Dict]]:

--- a/utils/vector_index.py
+++ b/utils/vector_index.py
@@ -96,11 +96,9 @@ def build_vector_index(
         vec = _text_to_vector(text)
         meta = {
             "entity_id": entity_id,
-            "friendly_name": st.get("attributes", {}).get("friendly_name"),
-            # Prefer top-level area_id injected by get_ha_states; fall back to
-            # any value stored under attributes for backward compatibility.
-            "area_id": st.get("area_id") or st.get("attributes", {}).get("area_id"),
             "domain": domain,
+            "area_id": st.get("area_id") or st.get("attributes", {}).get("area_id"),
+            "friendly_name": st.get("attributes", {}).get("friendly_name"),
         }
         docs.append({"page_content": text, "metadata": meta})
         vectors.append(vec)


### PR DESCRIPTION
## Summary
- expose helpers to resolve entity area & friendly name from Home Assistant registries
- enrich vector index metadata with domain, area_id and friendly_name
- add enrichment step to `build_vector_index_tool`
- test that mapping.json includes a light entity with an area

## Testing
- `pip install numpy voluptuous`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fab3069688332b256d1df57b91dd4