### PR TITLE
Add metadata-filtered search

### DIFF
--- a/tests/test_vector_index.py
+++ b/tests/test_vector_index.py
@@ -61,3 +61,37 @@ def test_mapping_contains_light_area(tmp_path):
         doc["metadata"].get("domain") == "light" and doc["metadata"].get("area_id")
         for doc in mapping
     )
+
+
+def test_query_vector_index_with_filters(tmp_path):
+    states = [
+        {
+            "entity_id": "light.office_ceiling",
+            "name": "Office Ceiling",
+            "attributes": {"friendly_name": "Office Ceiling"},
+            "area_id": "office",
+            "domain": "light",
+        },
+        {
+            "entity_id": "switch.office_fan",
+            "name": "Office Fan",
+            "attributes": {"friendly_name": "Office Fan"},
+            "area_id": "office",
+            "domain": "switch",
+        },
+    ]
+
+    persist = tmp_path / "index_filter"
+    index = build_vector_index(states, persist_dir=str(persist))
+
+    results = query_vector_index(
+        index,
+        "office light",
+        k=5,
+        filters={"area_id": "office", "domain": "light"},
+    )
+
+    assert any(
+        r["metadata"].get("domain") == "light" and "office" in (r["metadata"].get("area_id") or "")
+        for r in results
+    )

--- a/tool_specs/search_devices.py
+++ b/tool_specs/search_devices.py
@@ -1,16 +1,15 @@
-"""Tool for retrieving device entity_ids by similarity search."""
+"""Tool for retrieving device entity_ids by filtered similarity search."""
 
 from __future__ import annotations
 
 import logging
-from typing import List
+from typing import List, Any
 
 import voluptuous as vol
 
-from ..utils import logging as log
-from ..utils.constants import EXCLUDED_DOMAINS, PREFERRED_DOMAINS, LOCATION_WORDS
-from ..utils.vector_index import async_load_vector_index, query_vector_index
+from ..utils.vector_index import load_vector_index, query_vector_index
 from ..agent_core import ToolSpec
+from ..utils import logging as log
 
 _LOGGER = logging.getLogger(__package__)
 
@@ -18,45 +17,28 @@ _LOGGER = logging.getLogger(__package__)
 PARAMS = vol.Schema(
     {
         vol.Required("query"): str,
+        vol.Optional("area"): str,
+        vol.Optional("domain", default=["light", "switch"]): vol.Any(str, [str]),
         vol.Optional("k", default=5): int,
     }
 )
 
 
-async def search_devices(query: str, k: int = 5) -> List[str]:
-    """Return entity_ids matching the query from the vector index."""
-    index_data = await async_load_vector_index()
-    raw_results = query_vector_index(index_data, query, k, return_scores=True)
-
-    tokens = {t.rstrip('s') for t in query.lower().split()}
-    scored = []
-    for doc, score in raw_results:
-        entity_id = doc["metadata"].get("entity_id", "")
-        domain = entity_id.split(".")[0]
-        if domain in PREFERRED_DOMAINS:
-            score += 0.25
-        if domain in EXCLUDED_DOMAINS:
-            score -= 0.20
-
-        friendly = (doc["metadata"].get("friendly_name") or "").lower()
-        area = (doc["metadata"].get("area_id") or "").lower()
-        base = f"{entity_id.lower()} {friendly} {area}"
-        if any(
-            word in LOCATION_WORDS and (word in friendly or word in area)
-            for word in tokens
-        ):
-            score += 0.05
-
-        # boost for direct text matches
-        for token in tokens:
-            if token and token in base:
-                score += 0.05
-
-        scored.append((score, entity_id))
-
-    scored.sort(key=lambda x: x[0], reverse=True)
-    log.debug("Device search '%s' => %s", query, [e for _, e in scored])
-    return [e for _, e in scored]
+async def search_devices(
+    query: str,
+    area: str | None = None,
+    domain: str | list[str] | None = None,
+    k: int = 5,
+) -> List[str]:
+    """Return entity_ids matching the query with optional metadata filters."""
+    index_data = load_vector_index()
+    filters: dict[str, Any] = {}
+    if area:
+        filters["area_id"] = area
+    if domain:
+        filters["domain"] = domain
+    hits = query_vector_index(index_data, query, k, filters)
+    return [h["metadata"].get("entity_id", "") for h in hits]
 
 
 SPEC = ToolSpec(

--- a/utils/vector_index.py
+++ b/utils/vector_index.py
@@ -188,13 +188,39 @@ def query_vector_index(
     index_data: Tuple[np.ndarray, List[Dict]],
     query: str,
     k: int = 5,
+    filters: Dict[str, Any] | None = None,
     return_scores: bool = False,
 ) -> List[Dict] | List[Tuple[Dict, float]]:
-    """Query the index and return matching docs using cosine similarity."""
+    """Query the index and return matching docs using cosine similarity.
+
+    If ``filters`` is provided, only documents whose metadata match every
+    key/value pair are considered. Values may be single items or lists.
+    """
     if not index_data or index_data[0] is None:
         log.debug("query_vector_index: no index data")
         return []
     matrix, docs = index_data
+    if filters:
+        keep_indices = []
+        for idx, doc in enumerate(docs):
+            meta = doc.get("metadata", {})
+            match = True
+            for key, value in filters.items():
+                val = meta.get(key)
+                if isinstance(value, (list, tuple, set)):
+                    if val not in value:
+                        match = False
+                        break
+                else:
+                    if val != value:
+                        match = False
+                        break
+            if match:
+                keep_indices.append(idx)
+        if not keep_indices:
+            return []
+        matrix = matrix[keep_indices]
+        docs = [docs[i] for i in keep_indices]
     log.debug("Vector search query '%s' k=%s", query, k)
     vec = _text_to_vector(query)
     matrix_norm = matrix / (np.linalg.norm(matrix, axis=1, keepdims=True) + 1e-9)


### PR DESCRIPTION
## Summary
- support metadata filtering in `query_vector_index`
- rewrite `search_devices` tool to expose `area` and `domain` parameters
- add test for filtered search

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fb07eeb54833299ca426100016ee5