### PR TITLE
Implement roadmap phase 3 control tools

### DIFF
--- a/agent_core.py
+++ b/agent_core.py
@@ -39,6 +39,8 @@ class Agent:
         for mod in (
             "tool_specs.build_vector_index",  # always present
             "tool_specs.search_devices",      # optional / future
+            "tool_specs.confirm_action",      # phase 3
+            "tool_specs.control_device",      # phase 3
         ):
             module_name = f"{base}.{mod}" if base else mod
             try:

--- a/tests/test_control_tools.py
+++ b/tests/test_control_tools.py
@@ -1,0 +1,27 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from special_agent.tool_specs.confirm_action import confirm_action
+from special_agent.tool_specs.control_device import control_device
+from special_agent.agent_core import Agent
+
+
+def test_agent_loads_control_tools():
+    agent = Agent()
+    assert "confirm_action" in agent.tools
+    assert "control_device" in agent.tools
+
+
+def test_confirm_action_formats_question():
+    question = asyncio.run(confirm_action("turn on", ["light.kitchen"]))
+    assert "turn on" in question.lower()
+    assert "light.kitchen" in question
+
+
+def test_control_device_calls_service():
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    asyncio.run(control_device("light.turn_on", {"entity_id": "light.kitchen"}, hass=hass))
+    hass.services.async_call.assert_awaited_once_with(
+        "light", "turn_on", {"entity_id": "light.kitchen"}, blocking=True
+    )

--- a/tool_specs/confirm_action.py
+++ b/tool_specs/confirm_action.py
@@ -1,5 +1,37 @@
-"""Placeholder for confirm_action tool."""
+"""Ask the user to confirm a planned action."""
+
+from __future__ import annotations
 
 import logging
+from typing import List
+
+import voluptuous as vol
+
+from ..agent_core import ToolSpec
+from ..utils import logging as log
 
 _LOGGER = logging.getLogger(__package__)
+
+PARAMS = vol.Schema(
+    {
+        vol.Required("action"): str,
+        vol.Required("targets"): [str],
+    }
+)
+
+
+async def confirm_action(action: str, targets: List[str], hass=None) -> str:
+    """Return a formatted confirmation question."""
+    target_str = ", ".join(targets)
+    question = f"Do you want to {action} {target_str}?"
+    log.debug("confirm_action: %s", question)
+    return question
+
+
+SPEC = ToolSpec(
+    name="confirm_action",
+    description="Generate a confirmation question for the user.",
+    parameters=PARAMS,
+    returns="question string",
+    func=confirm_action,
+)

--- a/tool_specs/control_device.py
+++ b/tool_specs/control_device.py
@@ -1,5 +1,41 @@
-"""Placeholder for control_device tool."""
+"""Call a Home Assistant service to control a device."""
+
+from __future__ import annotations
 
 import logging
+from typing import Any
+
+import voluptuous as vol
+
+from ..agent_core import ToolSpec
+from ..utils import logging as log
 
 _LOGGER = logging.getLogger(__package__)
+
+PARAMS = vol.Schema(
+    {
+        vol.Required("service"): str,
+        vol.Optional("data", default={}): dict,
+    }
+)
+
+
+async def control_device(service: str, data: dict | None = None, hass: Any | None = None) -> str:
+    """Invoke a Home Assistant service."""
+    if hass is None:
+        raise RuntimeError("hass required")
+    if "." not in service:
+        raise ValueError("service must be of the form 'domain.name'")
+    domain, name = service.split(".", 1)
+    log.debug("control_device: %s %s", service, data)
+    await hass.services.async_call(domain, name, data or {}, blocking=True)
+    return "OK"
+
+
+SPEC = ToolSpec(
+    name="control_device",
+    description="Call a Home Assistant service like 'light.turn_on'.",
+    parameters=PARAMS,
+    returns="'OK' on success",
+    func=control_device,
+)


### PR DESCRIPTION
## Summary
- implement `confirm_action` and `control_device` tools
- load the new tools in `Agent.load_tools`
- add tests for control tools

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850bc73a3c0833299cbe093345317e5