### PR TITLE
Implement multi-session manager with prompt flow

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,20 @@ from __future__ import annotations
 
 import logging
 import os
+from datetime import timedelta
+
+try:
+    from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+    from homeassistant.helpers.event import async_track_time_interval
+except Exception:  # pragma: no cover - during unit tests
+    EVENT_HOMEASSISTANT_STOP = "ha_stop"
+    async def async_track_time_interval(*args, **kw):
+        return None
+
+try:
+    from .session_store import SessionManager
+except Exception:  # pragma: no cover
+    from session_store import SessionManager
 
 _LOGGER = logging.getLogger(__package__)
 
@@ -33,10 +47,19 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Special Agent from a config entry."""
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry.data
+    mgr = SessionManager(hass)
+    await mgr.load()
+    hass.data[DOMAIN]["sessions"] = mgr
     api_key = entry.options.get("openai_api_key") or entry.data.get("openai_api_key")
     if api_key and not os.environ.get("OPENAI_API_KEY"):
         os.environ["OPENAI_API_KEY"] = api_key
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    async def _save_sessions(_):
+        await mgr.save()
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _save_sessions)
+    async_track_time_interval(hass, lambda _: mgr.clear_expired(), timedelta(hours=1))
     return True
 
 

--- a/agent_core.py
+++ b/agent_core.py
@@ -7,13 +7,18 @@ import importlib
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 import os
+import time
 
 import voluptuous as vol
 
 try:
     from .utils import logging as log
+    from . import DOMAIN
+    from .session_store import Session
 except ImportError:  # pragma: no cover - support direct execution
     from utils import logging as log
+    from __init__ import DOMAIN
+    from session_store import Session
 
 # ----------  data classes ----------
 @dataclass
@@ -54,11 +59,17 @@ class Agent:
         log.info("Tool registered: %s", spec.name)
 
     # —— entry‑point ——
-    async def plan(self, user_input: str, hass: Any | None = None) -> str:
+    async def plan(
+        self,
+        user_input: str,
+        hass: Any | None = None,
+        session_key: tuple[str, str] | None = None,
+    ) -> Any:
         return await plan_execute(
             user_input,
             list(self.tools.values()),
             hass=hass,
+            session_key=session_key,
         )
 
 # ----------  helpers ----------
@@ -136,7 +147,8 @@ async def plan_execute(
     hass: Optional[Any] = None,
     model: str = "o4-mini",          # ← your tweak #1
     goals: Optional[List[str]] = None,   # ← new (can be None)
-) -> str:
+    session_key: tuple[str, str] | None = None,
+) -> Any:
     if not os.environ.get("OPENAI_API_KEY"):
         return "Sorry, I'm not ready to help yet."
 
@@ -185,6 +197,7 @@ async def plan_execute(
         "explicitly asked for them) and stop.\n"
         "When an external action is required, you MAY include both a Thought paragraph and "
         "tool_calls in the same message."
+        "\nRULES:\n- When you call confirm_action you MUST include a `question` field containing the exact sentence to speak."
     )
 
     log.debug("System_Prompt: %s", system_prompt)
@@ -192,10 +205,23 @@ async def plan_execute(
     log.debug("Tools_Provided: %s", tool_json)     # ← your tweak #2
 
     # ---- state ----
-    messages = [
-        {"role": "system", "content": system_prompt},
-        {"role": "user", "content": prompt},
-    ]
+    mgr = None
+    session = None
+    focus: Dict[str, Any] | None = None
+    if hass:
+        mgr = hass.data.get(DOMAIN, {}).get("sessions")
+        if session_key and mgr:
+            session = mgr.get(session_key)
+            if session:
+                messages = list(session.messages)
+                focus = session.focus
+                messages.append({"role": "user", "content": prompt})
+            else:
+                messages = [{"role": "system", "content": system_prompt}, {"role": "user", "content": prompt}]
+        else:
+            messages = [{"role": "system", "content": system_prompt}, {"role": "user", "content": prompt}]
+    else:
+        messages = [{"role": "system", "content": system_prompt}, {"role": "user", "content": prompt}]
     tried_calls: set[tuple[str, str]] = set()
     retry_budget = 2
     depth = 0
@@ -270,6 +296,11 @@ async def plan_execute(
             else:
                 result = await spec.func(**args)
 
+            if call_name == "control_device" and result == "OK":
+                ent = args.get("data", {}).get("entity_id") if isinstance(args, dict) else None
+                t = ent if isinstance(ent, list) else [ent] if ent else None
+                focus = {"targets": t, "action": args.get("service")}
+
             # feed back – store SUMMARISED observation
             content_summary = _summarise(result)
             msg_dict = msg.model_dump() if hasattr(msg, "model_dump") else msg.dict()
@@ -284,6 +315,19 @@ async def plan_execute(
                     },
                 ]
             )
+            if isinstance(result, dict) and "speak" in result:
+                if mgr and session_key:
+                    mgr.set(
+                        session_key,
+                        Session(
+                            messages=messages,
+                            pending=result.get("pending"),
+                            focus=focus,
+                            device_id=session_key[1],
+                            updated=time.time(),
+                        ),
+                    )
+                return {"prompt_payload": result, "messages": messages}
             depth += 1
             if retry_budget > 0:
                 retry_budget -= 1
@@ -291,6 +335,8 @@ async def plan_execute(
 
         # ---------- final answer ----------
         log.debug("Final Message: %s", messages)
+        if mgr and session_key:
+            mgr.pop(session_key)
         return msg.content or "OK"
 
     return "Depth‑limit reached."

--- a/conversation.py
+++ b/conversation.py
@@ -11,6 +11,7 @@ from homeassistant.components.conversation import (
 from homeassistant.helpers import intent
 
 from .agent_core import Agent
+from . import DOMAIN
 
 _LOGGER = logging.getLogger(__package__)
 
@@ -48,10 +49,34 @@ class SpecialAgentConversation(ConversationEntity, AbstractConversationAgent):
 
     async def async_process(self, conversation_input, context=None) -> ConversationResult:
         user_text = getattr(conversation_input, "text", "")
-        result_text = await self.agent.plan(user_text, hass=self.hass)
+        sess_key = (conversation_input.conversation_id, conversation_input.device_id)
+        result = await self.agent.plan(
+            user_text, hass=self.hass, session_key=sess_key
+        )
 
+        mgr = self.hass.data[DOMAIN]["sessions"]
+
+        if isinstance(result, dict) and "prompt_payload" in result:
+            await mgr.save()
+            await self.hass.services.async_call(
+                "assist_pipeline",
+                "run",
+                {
+                    "conversation_id": conversation_input.conversation_id,
+                    "device_id": conversation_input.device_id,
+                    "prompt": result["prompt_payload"]["speak"],
+                    "listen_for_response": True,
+                },
+                blocking=True,
+            )
+            response = intent.IntentResponse(language=conversation_input.language)
+            response.async_set_speech(result["prompt_payload"]["speak"])
+            return ConversationResult(
+                conversation_id=conversation_input.conversation_id,
+                response=response,
+            )
         response = intent.IntentResponse(language=conversation_input.language)
-        response.async_set_speech(result_text)
+        response.async_set_speech(str(result))
         return ConversationResult(
             conversation_id=conversation_input.conversation_id,
             response=response,

--- a/session_store.py
+++ b/session_store.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Any, Dict
+import time
+
+try:
+    from homeassistant.helpers.storage import Store
+except Exception:  # pragma: no cover - during unit tests
+    class Store:  # type: ignore
+        def __init__(self, *args, **kw):
+            self._data = {}
+
+        async def async_load(self):
+            return self._data
+
+        async def async_save(self, data):
+            self._data = data
+
+try:
+    from .utils import logging as log
+except Exception:  # pragma: no cover - direct execution
+    from utils import logging as log
+
+
+@dataclass
+class Session:
+    """Dataclass for a persisted conversation session."""
+
+    messages: list
+    pending: Dict[str, Any] | None
+    focus: Dict[str, Any] | None
+    device_id: str
+    updated: float
+
+
+class SessionManager:
+    """Manage persisted sessions for multiple devices."""
+
+    def __init__(self, hass) -> None:
+        self._hass = hass
+        self._store = Store(hass, 1, ".special_agent_sessions.json")
+        self._data: Dict[str, Session] = {}
+
+    async def load(self) -> None:
+        data = await self._store.async_load() or {}
+        self._data = {k: Session(**v) for k, v in data.items()}
+        log.debug("SessionManager loaded %s sessions", len(self._data))
+
+    async def save(self) -> None:
+        await self._store.async_save({k: asdict(v) for k, v in self._data.items()})
+        log.debug("SessionManager saved %s sessions", len(self._data))
+
+    @staticmethod
+    def _fmt(key: tuple[str, str] | str) -> str:
+        if isinstance(key, tuple):
+            return f"{key[0]}|{key[1]}"
+        return key
+
+    def get(self, key: tuple[str, str] | str) -> Session | None:
+        return self._data.get(self._fmt(key))
+
+    def set(self, key: tuple[str, str] | str, session: Session) -> None:
+        self._data[self._fmt(key)] = session
+
+    def pop(self, key: tuple[str, str] | str) -> Session | None:
+        return self._data.pop(self._fmt(key), None)
+
+    def clear_expired(self, ttl: int = 300) -> None:
+        cutoff = time.time() - ttl
+        for k in list(self._data):
+            if self._data[k].updated < cutoff:
+                log.debug("Session expired: %s", k)
+                self._data.pop(k)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,11 +6,30 @@ import pytest
 os.environ.setdefault("SPECIAL_AGENT_TESTING", "true")
 
 import sys
+import types
 
-sys.modules.setdefault("homeassistant", MagicMock())
+sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
 sys.modules.setdefault("homeassistant.core", MagicMock())
-sys.modules.setdefault("homeassistant.helpers", MagicMock())
-sys.modules.setdefault("homeassistant.helpers.intent", MagicMock())
+sys.modules.setdefault("homeassistant.config_entries", MagicMock())
+helpers = types.ModuleType("homeassistant.helpers")
+helpers.event = types.ModuleType("homeassistant.helpers.event")
+helpers.event.async_track_time_interval = MagicMock()
+helpers.storage = types.ModuleType("homeassistant.helpers.storage")
+helpers.storage.Store = MagicMock()
+helpers.intent = MagicMock()
+helpers.area_registry = MagicMock()
+helpers.device_registry = MagicMock()
+helpers.entity_registry = MagicMock()
+sys.modules.setdefault("homeassistant.helpers", helpers)
+sys.modules.setdefault("homeassistant.helpers.event", helpers.event)
+sys.modules.setdefault("homeassistant.helpers.storage", helpers.storage)
+sys.modules.setdefault("homeassistant.helpers.area_registry", helpers.area_registry)
+sys.modules.setdefault("homeassistant.helpers.device_registry", helpers.device_registry)
+sys.modules.setdefault("homeassistant.helpers.entity_registry", helpers.entity_registry)
+sys.modules.setdefault("homeassistant.helpers.intent", helpers.intent)
+const_mod = types.ModuleType("homeassistant.const")
+const_mod.EVENT_HOMEASSISTANT_STOP = "stop"
+sys.modules.setdefault("homeassistant.const", const_mod)
 
 
 @pytest.fixture

--- a/tests/test_confirm_question.py
+++ b/tests/test_confirm_question.py
@@ -1,0 +1,65 @@
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from special_agent.agent_core import Agent, plan_execute
+from special_agent.session_store import SessionManager
+from special_agent import DOMAIN
+
+
+class FakeClient:
+    def __init__(self, msg):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
+        self._msg = msg
+
+    async def _create(self, *args, **kw):
+        return SimpleNamespace(choices=[SimpleNamespace(message=self._msg)])
+
+
+def make_msg():
+    call = SimpleNamespace(
+        id="1",
+        function=SimpleNamespace(
+            name="confirm_action",
+            arguments=json.dumps({
+                "action": "turn off",
+                "targets": ["light.kitchen"],
+                "question": "Turn off kitchen?",
+            }),
+        ),
+    )
+    class ToolList(list):
+        @property
+        def function(self):
+            return self[0].function
+
+    tool_list = ToolList([call])
+    msg = SimpleNamespace(
+        content=None,
+        tool_calls=tool_list,
+        model_dump=lambda: {"content": None, "tool_calls": tool_list},
+        dict=lambda: {"content": None, "tool_calls": tool_list},
+    )
+    return msg
+
+
+def test_confirm_question(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "1")
+    msg = make_msg()
+
+    async def get_client(hass=None):
+        return FakeClient(msg)
+
+    monkeypatch.setattr("special_agent.utils.openai_client.get_async_client", get_client)
+
+    hass = MagicMock()
+    mgr = SessionManager(hass)
+    hass.data = {DOMAIN: {"sessions": mgr}}
+
+    agent = Agent()
+
+    result = asyncio.run(plan_execute("hi", list(agent.tools.values()), hass=hass, session_key=("c", "dev")))
+
+    assert isinstance(result, dict) and "prompt_payload" in result
+    assert mgr.get("c|dev") is not None

--- a/tests/test_control_tools.py
+++ b/tests/test_control_tools.py
@@ -13,9 +13,16 @@ def test_agent_loads_control_tools():
 
 
 def test_confirm_action_formats_question():
-    question = asyncio.run(confirm_action("turn on", ["light.kitchen"]))
-    assert "turn on" in question.lower()
-    assert "light.kitchen" in question
+    result = asyncio.run(
+        confirm_action(
+            "turn on",
+            ["light.kitchen"],
+            question="Turn on the kitchen light?",
+        )
+    )
+    assert result["kind"] == "confirm"
+    assert "turn on" in result["speak"].lower()
+    assert "kitchen" in result["speak"].lower()
 
 
 def test_control_device_calls_service():

--- a/tests/test_multi_session.py
+++ b/tests/test_multi_session.py
@@ -1,0 +1,76 @@
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from special_agent.agent_core import Agent, plan_execute
+from special_agent.session_store import SessionManager
+from special_agent import DOMAIN
+
+
+class FakeClient:
+    def __init__(self, msg):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
+        self._msg = msg
+
+    async def _create(self, *args, **kw):
+        return SimpleNamespace(choices=[SimpleNamespace(message=self._msg)])
+
+
+@pytest.fixture
+def fake_openai(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "1")
+
+    def factory(msg):
+        async def get_client(hass=None):
+            return FakeClient(msg)
+        monkeypatch.setattr(
+            "special_agent.utils.openai_client.get_async_client", get_client
+        )
+    return factory
+
+
+def make_msg():
+    call = SimpleNamespace(
+        id="1",
+        function=SimpleNamespace(
+            name="confirm_action",
+            arguments=json.dumps({
+                "action": "turn on",
+                "targets": ["light.kitchen"],
+                "question": "Turn on kitchen?",
+            }),
+        ),
+    )
+    class ToolList(list):
+        @property
+        def function(self):
+            return self[0].function
+
+    tool_list = ToolList([call])
+    msg = SimpleNamespace(
+        content=None,
+        tool_calls=tool_list,
+        model_dump=lambda: {"content": None, "tool_calls": tool_list},
+        dict=lambda: {"content": None, "tool_calls": tool_list},
+    )
+    return msg
+
+
+def test_multi_session(fake_openai):
+    msg = make_msg()
+    fake_openai(msg)
+    hass = MagicMock()
+    mgr = SessionManager(hass)
+    hass.data = {DOMAIN: {"sessions": mgr}}
+
+    agent = Agent()
+
+    res1 = asyncio.run(plan_execute("hi", list(agent.tools.values()), hass=hass, session_key=("a", "dev1")))
+    res2 = asyncio.run(plan_execute("hi", list(agent.tools.values()), hass=hass, session_key=("b", "dev2")))
+
+    assert isinstance(res1, dict) and "prompt_payload" in res1
+    assert mgr.get("a|dev1") is not None
+    assert mgr.get("b|dev2") is not None


### PR DESCRIPTION
## Summary
- add `session_store.py` with Session dataclass and manager
- persist SessionManager in `__init__.py`
- extend `agent_core.plan_execute` with session support
- update conversation agent to resume sessions and speak via assist pipeline
- enforce confirm_action question rule in system prompt
- add tests for session behaviour and confirm questions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685250d384cc833281308d2a09f7c203