### PR TITLE
Fix missing assist pipeline service

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "name": "Special Agent",
     "version": "0.0.1",
     "documentation": "https://example.com",
-    "dependencies": ["conversation"],
+    "dependencies": ["conversation", "assist_pipeline"],
     "requirements": [
         "langchain",
         "openai",


### PR DESCRIPTION
## Summary
- declare assist_pipeline as a dependency so its services are registered

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68531e8e93ac8332af7381dbb8bebdab