### PR TITLE
Improve tool error handling

### DIFF
--- a/agent_core.py
+++ b/agent_core.py
@@ -330,10 +330,28 @@ async def plan_execute(
                 continue
             # ---------------------------------------------
             log.debug("Action: %s %s", call_name, args)
-            if hass and "hass" in inspect.signature(spec.func).parameters:
-                result = await spec.func(hass=hass, **args)
-            else:
-                result = await spec.func(**args)
+            try:
+                if hass and "hass" in inspect.signature(spec.func).parameters:
+                    result = await spec.func(hass=hass, **args)
+                else:
+                    result = await spec.func(**args)
+            except Exception as err:
+                log.error("Tool execution failed: %s", err)
+                messages.append(
+                    {
+                        "role": "assistant",
+                        "content": (
+                            f"Thought: Execution of {call_name} failed (`{err}`). "
+                            "Please adjust the parameters and try again. Confidence: 20%"
+                        ),
+                    }
+                )
+                depth += 1
+                if retry_budget > 0:
+                    retry_budget -= 1
+                    continue
+                _clear_session(mgr, session_key)
+                return f"Error: {err}"
 
             if call_name == "control_device":
                 focus = {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,11 +4,24 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, AsyncMock
 
 from special_agent.__init__ import async_setup_entry
+from special_agent import session_store
+
+
+class StubStore:
+    def __init__(self, *args, **kw):
+        self._data = {}
+
+    async def async_load(self):
+        return self._data
+
+    async def async_save(self, data):
+        self._data = data
 
 
 def test_setup_entry_sets_env(monkeypatch):
     hass = MagicMock()
     hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    monkeypatch.setattr(session_store, "Store", StubStore)
     entry = SimpleNamespace(entry_id="1", data={"openai_api_key": "key"}, options={})
     asyncio.run(async_setup_entry(hass, entry))
     assert os.environ.get("OPENAI_API_KEY") == "key"

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,79 @@
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from special_agent.agent_core import Agent, plan_execute
+from special_agent.session_store import SessionManager
+from special_agent import DOMAIN
+
+
+class FakeClient:
+    def __init__(self, msgs):
+        self._msgs = list(msgs)
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
+
+    async def _create(self, *args, **kw):
+        msg = self._msgs.pop(0)
+        return SimpleNamespace(choices=[SimpleNamespace(message=msg)])
+
+
+def make_err_msg():
+    call = SimpleNamespace(
+        id="1",
+        function=SimpleNamespace(
+            name="control_device",
+            arguments=json.dumps(
+                {
+                    "service": "climate.set_temperature",
+                    "data": {"entity_id": ["climate.main"], "temperature": -5},
+                }
+            ),
+        ),
+    )
+    class ToolList(list):
+        @property
+        def function(self):
+            return self[0].function
+
+    tool_list = ToolList([call])
+    msg = SimpleNamespace(
+        content=None,
+        tool_calls=tool_list,
+        model_dump=lambda: {"content": None, "tool_calls": tool_list},
+        dict=lambda: {"content": None, "tool_calls": tool_list},
+    )
+    return msg
+
+
+@pytest.mark.asyncio
+async def test_control_device_error(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "1")
+    msgs = [make_err_msg(), make_err_msg()]
+    monkeypatch.setattr(
+        "special_agent.utils.openai_client.get_async_client",
+        lambda hass=None: FakeClient(msgs),
+    )
+
+    async def bad_control_device(*args, **kw):
+        raise Exception(
+            "Provided temperature -5 is not valid. Accepted range is 1 to 37"
+        )
+
+    from special_agent.tool_specs import control_device as cd
+
+    monkeypatch.setattr(cd, "control_device", bad_control_device)
+    monkeypatch.setattr(cd.SPEC, "func", bad_control_device)
+
+    hass = MagicMock()
+    mgr = SessionManager(hass)
+    hass.data = {DOMAIN: {"sessions": mgr}}
+
+    agent = Agent()
+    result = await plan_execute(
+        "hi", list(agent.tools.values()), hass=hass, session_key=("c", "dev")
+    )
+
+    assert "not valid" in str(result)


### PR DESCRIPTION
## Summary
- raise service errors up to the LLM rather than crashing
- stub out HA `Store` in config flow test
- add regression test for service error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68534312ab908332b31d1e6d86834936