### PR TITLE
Implement search_spotify tool

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -53,6 +53,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     api_key = entry.options.get("openai_api_key") or entry.data.get("openai_api_key")
     if api_key and not os.environ.get("OPENAI_API_KEY"):
         os.environ["OPENAI_API_KEY"] = api_key
+    sp_id = entry.options.get("spotify_client_id") or entry.data.get("spotify_client_id")
+    sp_secret = entry.options.get("spotify_client_secret") or entry.data.get("spotify_client_secret")
+    if sp_id and not os.environ.get("SPOTIFY_CLIENT_ID"):
+        os.environ["SPOTIFY_CLIENT_ID"] = sp_id
+    if sp_secret and not os.environ.get("SPOTIFY_CLIENT_SECRET"):
+        os.environ["SPOTIFY_CLIENT_SECRET"] = sp_secret
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     async def _save_sessions(_):

--- a/config_flow.py
+++ b/config_flow.py
@@ -25,7 +25,13 @@ class SpecialAgentConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema({vol.Required("openai_api_key"): str}),
+            data_schema=vol.Schema(
+                {
+                    vol.Required("openai_api_key"): str,
+                    vol.Optional("spotify_client_id", default=""): str,
+                    vol.Optional("spotify_client_secret", default=""): str,
+                }
+            ),
         )
 
     @staticmethod
@@ -54,7 +60,21 @@ class SpecialAgentOptionsFlow(config_entries.OptionsFlow):
                         "openai_api_key",
                         self.config_entry.data.get("openai_api_key", ""),
                     ),
-                ): str
+                ): str,
+                vol.Optional(
+                    "spotify_client_id",
+                    default=current.get(
+                        "spotify_client_id",
+                        self.config_entry.data.get("spotify_client_id", ""),
+                    ),
+                ): str,
+                vol.Optional(
+                    "spotify_client_secret",
+                    default=current.get(
+                        "spotify_client_secret",
+                        self.config_entry.data.get("spotify_client_secret", ""),
+                    ),
+                ): str,
             }
         )
         return self.async_show_form(step_id="init", data_schema=schema)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -22,6 +22,29 @@ def test_setup_entry_sets_env(monkeypatch):
     hass = MagicMock()
     hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
     monkeypatch.setattr(session_store, "Store", StubStore)
-    entry = SimpleNamespace(entry_id="1", data={"openai_api_key": "key"}, options={})
+    entry = SimpleNamespace(
+        entry_id="1",
+        data={
+            "openai_api_key": "key",
+            "spotify_client_id": "cid",
+            "spotify_client_secret": "secret",
+        },
+        options={},
+    )
     asyncio.run(async_setup_entry(hass, entry))
     assert os.environ.get("OPENAI_API_KEY") == "key"
+    assert os.environ.get("SPOTIFY_CLIENT_ID") == "cid"
+    assert os.environ.get("SPOTIFY_CLIENT_SECRET") == "secret"
+
+
+def test_setup_entry_without_spotify(monkeypatch):
+    hass = MagicMock()
+    hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    monkeypatch.setattr(session_store, "Store", StubStore)
+    monkeypatch.delenv("SPOTIFY_CLIENT_ID", raising=False)
+    monkeypatch.delenv("SPOTIFY_CLIENT_SECRET", raising=False)
+    entry = SimpleNamespace(entry_id="2", data={"openai_api_key": "key2"}, options={})
+    asyncio.run(async_setup_entry(hass, entry))
+    assert os.environ.get("OPENAI_API_KEY") == "key"
+    assert os.environ.get("SPOTIFY_CLIENT_ID") is None
+    assert os.environ.get("SPOTIFY_CLIENT_SECRET") is None

--- a/tests/test_search_spotify_tool.py
+++ b/tests/test_search_spotify_tool.py
@@ -1,0 +1,14 @@
+import asyncio
+
+from special_agent.tool_specs.search_spotify import search_spotify
+
+
+async def run_tool():
+    return await search_spotify("hello", type="track")
+
+
+def test_search_spotify_missing_creds(monkeypatch):
+    monkeypatch.delenv("SPOTIFY_CLIENT_ID", raising=False)
+    monkeypatch.delenv("SPOTIFY_CLIENT_SECRET", raising=False)
+    result = asyncio.run(run_tool())
+    assert result is None

--- a/tool_specs/search_spotify.py
+++ b/tool_specs/search_spotify.py
@@ -1,5 +1,38 @@
-"""Placeholder for search_spotify tool."""
+"""Search Spotify for a URI."""
+
+from __future__ import annotations
 
 import logging
+from typing import Any
+
+import voluptuous as vol
+
+from ..agent_core import ToolSpec
+from ..utils.spotify import search_spotify as _search
+from ..utils import logging as log
 
 _LOGGER = logging.getLogger(__package__)
+
+
+PARAMS = vol.Schema(
+    {
+        vol.Required("query"): str,
+        vol.Optional("type", default="track"): vol.In(["track", "artist", "album", "playlist"]),
+    }
+)
+
+
+async def search_spotify(query: str, type: str = "track", hass: Any | None = None) -> str | None:
+    """Return the Spotify URI for the given query."""
+    uri = await _search(query, search_type=type, hass=hass)
+    log.debug("search_spotify uri=%s", uri)
+    return uri
+
+
+SPEC = ToolSpec(
+    name="search_spotify",
+    description="Search Spotify and return the first result URI.",
+    parameters=PARAMS,
+    returns="spotify uri or null",
+    func=search_spotify,
+)

--- a/utils/spotify.py
+++ b/utils/spotify.py
@@ -1,0 +1,79 @@
+"""Minimal Spotify Web API helpers."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any
+
+import aiohttp
+
+from . import logging as log
+
+_LOGGER = logging.getLogger(__package__)
+
+SPOTIFY_API_BASE_URL = "https://api.spotify.com/v1"
+_TOKEN: dict[str, Any] = {"access_token": None, "expires_at": 0}
+
+_SEARCH_TYPE_KEY_MAP = {
+    "track": "tracks",
+    "artist": "artists",
+    "album": "albums",
+    "playlist": "playlists",
+}
+
+
+async def get_spotify_access_token(hass: Any | None = None) -> str | None:
+    """Return a cached Spotify access token using Client Credentials flow."""
+    client_id = os.environ.get("SPOTIFY_CLIENT_ID")
+    client_secret = os.environ.get("SPOTIFY_CLIENT_SECRET")
+    if not client_id or not client_secret:
+        log.debug("Spotify credentials missing")
+        return None
+
+    now = time.time()
+    if _TOKEN.get("access_token") and now < _TOKEN["expires_at"] - 60:
+        return _TOKEN["access_token"]
+
+    token_url = "https://accounts.spotify.com/api/token"
+    data = {"grant_type": "client_credentials"}
+    auth = aiohttp.BasicAuth(client_id.strip(), client_secret.strip())
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(token_url, data=data, auth=auth) as resp:
+            if resp.status == 200:
+                payload = await resp.json()
+                _TOKEN["access_token"] = payload.get("access_token")
+                _TOKEN["expires_at"] = now + payload.get("expires_in", 0)
+                return _TOKEN["access_token"]
+            log.debug("Spotify token error: %s - %s", resp.status, await resp.text())
+            return None
+
+
+async def search_spotify(
+    query: str,
+    search_type: str = "track",
+    limit: int = 1,
+    market: str = "US",
+    hass: Any | None = None,
+) -> str | None:
+    """Search Spotify and return the first result URI."""
+    token = await get_spotify_access_token(hass)
+    if not token:
+        return None
+
+    headers = {"Authorization": f"Bearer {token}"}
+    params = {"q": query, "type": search_type, "limit": limit, "market": market}
+
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"{SPOTIFY_API_BASE_URL}/search", headers=headers, params=params) as resp:
+            if resp.status == 200:
+                data = await resp.json()
+                plural = _SEARCH_TYPE_KEY_MAP.get(search_type, f"{search_type}s")
+                items = data.get(plural, {}).get("items", [])
+                if items:
+                    return items[0].get("uri")
+                return None
+            log.debug("Spotify search error: %s - %s", resp.status, await resp.text())
+            return None


### PR DESCRIPTION
## Summary
- add optional Spotify credentials to config entry and options
- set Spotify credentials as env vars if provided
- implement Spotify Web API helpers
- implement search_spotify tool spec
- add tests for config flow and missing credentials

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68535b8a343083329646cdc5e85c3197