### PR TITLE
clarify spotify search workflow

### DIFF
--- a/tool_specs/search_spotify.py
+++ b/tool_specs/search_spotify.py
@@ -31,7 +31,12 @@ async def search_spotify(query: str, type: str = "track", hass: Any | None = Non
 
 SPEC = ToolSpec(
     name="search_spotify",
-    description="Search Spotify and return the first result URI.",
+    description=(
+        "Search Spotify and return the first result URI. "
+        "Use this tool to look up a track, artist, album or playlist before "
+        "calling 'media_player.play_media'. Pass the returned URI as the "
+        "'media_content_id'."
+    ),
     parameters=PARAMS,
     returns="spotify uri or null",
     func=search_spotify,


### PR DESCRIPTION
## Summary
- clarify search_spotify spec so the agent knows to look up a URI before playing music

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685360a4707c8332a9ef5d78cca9a405