### PR TITLE
Improve session persistence for follow‑ups

### DIFF
--- a/agent_core.py
+++ b/agent_core.py
@@ -193,6 +193,36 @@ def _clear_session(mgr: Any | None, session_key: tuple[str, str] | None) -> None
     if mgr and session_key:
         mgr.pop(session_key)
 
+
+async def _is_followup_prompt(
+    client: Any, history: list[Dict[str, Any]], prompt: str
+) -> bool:
+    """Ask the LLM if the prompt continues the same conversation."""
+    if not history:
+        return False
+    hist_text = "\n".join(
+        f"{m['role']}: {m['content']}" for m in history[-4:] if m.get("content")
+    )
+    eval_messages = [
+        {
+            "role": "system",
+            "content": (
+                "Answer yes or no: Does the NEW prompt continue the same topic as "
+                "the prior conversation? Reply only 'yes' or 'no'."
+            ),
+        },
+        {"role": "user", "content": f"{hist_text}\nNEW PROMPT: {prompt}"},
+    ]
+    try:
+        resp = await client.chat.completions.create(
+            model="o4-mini", messages=eval_messages
+        )
+        answer = resp.choices[0].message.content.strip().lower()
+        return answer.startswith("yes")
+    except Exception as err:  # pragma: no cover - fallback
+        log.debug("Follow-up check failed: %s", err)
+    return False
+
 # ----------  ReAct loop ----------
 async def plan_execute(
     prompt: str,
@@ -259,6 +289,19 @@ async def plan_execute(
 
     # ---- state ----
     messages, mgr, focus = _load_session(hass, session_key, system_prompt, prompt)
+    if focus:
+        try:
+            follow = await _is_followup_prompt(client, messages[:-1], prompt)
+        except Exception as err:  # pragma: no cover
+            log.debug("Follow-up check error: %s", err)
+            follow = False
+        if not follow:
+            _clear_session(mgr, session_key)
+            messages = [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt},
+            ]
+            focus = None
     tried_calls: set[tuple[str, str]] = set()
     retry_budget = 2
     depth = 0
@@ -387,7 +430,7 @@ async def plan_execute(
 
         # ---------- final answer ----------
         log.debug("Final Message: %s", messages)
-        _clear_session(mgr, session_key)
+        _store_session(mgr, session_key, messages, None, focus)
         return msg.content or "OK"
 
     return "Depth‑limit reached."

--- a/tests/test_multi_session.py
+++ b/tests/test_multi_session.py
@@ -32,6 +32,55 @@ def fake_openai(monkeypatch):
     return factory
 
 
+class SeqClient:
+    """Fake client that yields a sequence of messages."""
+
+    def __init__(self, msgs):
+        self._msgs = list(msgs)
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
+
+    async def _create(self, *args, **kw):
+        msg = self._msgs.pop(0)
+        return SimpleNamespace(choices=[SimpleNamespace(message=msg)])
+
+
+def _control_msg(brightness):
+    call = SimpleNamespace(
+        id="1",
+        function=SimpleNamespace(
+            name="control_device",
+            arguments=json.dumps(
+                {
+                    "service": "light.turn_on",
+                    "data": {"entity_id": ["light.kitchen"], "brightness_pct": brightness},
+                }
+            ),
+        ),
+    )
+
+    class ToolList(list):
+        @property
+        def function(self):
+            return self[0].function
+
+    tool_list = ToolList([call])
+    return SimpleNamespace(
+        content=None,
+        tool_calls=tool_list,
+        model_dump=lambda: {"content": None, "tool_calls": tool_list},
+        dict=lambda: {"content": None, "tool_calls": tool_list},
+    )
+
+
+def _text_msg(text="done"):
+    return SimpleNamespace(
+        content=text,
+        tool_calls=None,
+        model_dump=lambda: {"content": text, "tool_calls": None},
+        dict=lambda: {"content": text, "tool_calls": None},
+    )
+
+
 def make_msg():
     call = SimpleNamespace(
         id="1",
@@ -74,3 +123,55 @@ def test_multi_session(fake_openai):
     assert isinstance(res1, dict) and "prompt_payload" in res1
     assert mgr.get("a|dev1") is not None
     assert mgr.get("b|dev2") is not None
+
+
+def test_percent_followup(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "1")
+
+    hass = MagicMock()
+    hass.services.async_call = MagicMock()
+    mgr = SessionManager(hass)
+    hass.data = {DOMAIN: {"sessions": mgr}}
+
+    agent = Agent()
+
+    async def stub_control(service: str, data: dict | None = None, hass=None):
+        hass.services.async_call(service.split(".")[0], service.split(".")[1], data or {}, blocking=True)
+        return {"status": "OK", "focus": {"targets": data.get("entity_id"), "action": service}}
+
+    from special_agent.tool_specs import control_device as cd
+
+    monkeypatch.setattr(cd, "control_device", stub_control)
+    monkeypatch.setattr(cd.SPEC, "func", stub_control)
+
+    # first command -> brightness 5
+    msgs1 = [_control_msg(5), _text_msg()]
+    async def get_client1(hass=None):
+        return SeqClient(msgs1)
+
+    monkeypatch.setattr(
+        "special_agent.utils.openai_client.get_async_client",
+        get_client1,
+    )
+    res1 = asyncio.run(
+        plan_execute("office lights 5%", list(agent.tools.values()), hass=hass, session_key=("a", "dev"))
+    )
+    assert res1 == "done"
+    assert mgr.get("a|dev").focus["targets"] == ["light.kitchen"]
+
+    # follow-up with percent only
+    msgs2 = [_text_msg("yes"), _control_msg(6), _text_msg("done2")]
+    async def get_client2(hass=None):
+        return SeqClient(msgs2)
+
+    monkeypatch.setattr(
+        "special_agent.utils.openai_client.get_async_client",
+        get_client2,
+    )
+    res2 = asyncio.run(
+        plan_execute("6%", list(agent.tools.values()), hass=hass, session_key=("a", "dev"))
+    )
+    assert res2 == "done2"
+    hass.services.async_call.assert_any_call(
+        "light", "turn_on", {"entity_id": ["light.kitchen"], "brightness_pct": 6}, blocking=True
+    )


### PR DESCRIPTION
## Summary
- store sessions instead of clearing them so follow-ups can re-use focus
- ask the model if a new user prompt continues the same topic
- use session focus when confirming follow-up commands

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68539815bca08332b7e4a0565fc51a4e