### PR TITLE
Add entity state/history tools

### DIFF
--- a/agent_core.py
+++ b/agent_core.py
@@ -48,6 +48,8 @@ class Agent:
             "tool_specs.search_devices",
             "tool_specs.control_device",
             "tool_specs.search_spotify",
+            "tool_specs.get_entity_state",
+            "tool_specs.get_entity_history",
         ):
             module_name = f"{base}.{mod}" if base else mod
             try:

--- a/tests/test_entity_tools.py
+++ b/tests/test_entity_tools.py
@@ -1,0 +1,144 @@
+import asyncio
+import importlib
+import sys
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock, AsyncMock
+
+from special_agent.agent_core import Agent
+import pytest
+
+
+def test_agent_loads_entity_tools():
+    agent = Agent()
+    assert "get_entity_state" in agent.tools
+    assert "get_entity_history" in agent.tools
+
+
+async def run_get_state(tool, hass):
+    return await tool(["light.kitchen"], attributes=["brightness"], hass=hass)
+
+
+def test_get_entity_state(monkeypatch):
+    from special_agent.tool_specs import get_entity_state as ges
+
+    state_obj = SimpleNamespace(state="on", attributes={"brightness": 200})
+    hass = MagicMock()
+    hass.states.get = MagicMock(return_value=state_obj)
+
+    result = asyncio.run(run_get_state(ges.get_entity_state, hass))
+
+    assert result["light.kitchen"]["state"] == "on"
+    assert result["light.kitchen"]["brightness"] == 200
+
+
+def test_state_empty_list_fails():
+    from special_agent.tool_specs import get_entity_state as ges
+
+    with pytest.raises(Exception):
+        ges.PARAMS({"entity_ids": []})
+
+
+def test_get_entity_history(monkeypatch):
+    events = [
+        SimpleNamespace(state="off", last_changed=datetime(2023, 1, 1, 12, 0)),
+        SimpleNamespace(state="on", last_changed=datetime(2023, 1, 1, 13, 0)),
+    ]
+
+    def fake_history(hass, start, end, entity_ids, significant):
+        return {entity_ids[0]: events}
+
+    history_mod = SimpleNamespace(get_significant_states=fake_history)
+    sys.modules["homeassistant.components.history"] = history_mod
+
+    import special_agent.tool_specs.get_entity_history as geh
+    importlib.reload(geh)
+
+    hass = MagicMock()
+    hass.async_add_executor_job = AsyncMock(
+        side_effect=lambda func, *a, **kw: func(*a, **kw)
+    )
+
+    result = asyncio.run(
+        geh.get_entity_history("light.kitchen", lookback_hours=1, limit=1, hass=hass)
+    )
+
+    assert result[0]["state"] == "on"
+    assert "when" in result[0]
+
+
+def test_history_cap_applied(monkeypatch):
+    base = datetime(2023, 1, 1, 12, 0)
+    events = [
+        SimpleNamespace(state="on", last_changed=base + timedelta(minutes=i))
+        for i in range(150)
+    ]
+
+    def fake_history(hass, start, end, entity_ids, significant):
+        return {entity_ids[0]: events}
+
+    sys.modules["homeassistant.components.history"] = SimpleNamespace(
+        get_significant_states=fake_history
+    )
+
+    import special_agent.tool_specs.get_entity_history as geh
+    importlib.reload(geh)
+
+    hass = MagicMock()
+    hass.async_add_executor_job = AsyncMock(
+        side_effect=lambda func, *a, **kw: func(*a, **kw)
+    )
+
+    result = asyncio.run(
+        geh.get_entity_history(
+            "sensor.test",
+            lookback_hours=1,
+            limit=200,
+            hass=hass,
+        )
+    )
+
+    assert len(result) == geh.MAX_EVENTS
+
+
+def test_history_iso_range(monkeypatch):
+    base = datetime(2023, 1, 1, 0, 0)
+    events = [
+        SimpleNamespace(state=str(i), last_changed=base + timedelta(hours=i))
+        for i in range(4)
+    ]
+
+    def fake_history(hass, start, end, entity_ids, significant):
+        selected = [e for e in events if (not start or e.last_changed >= start) and (not end or e.last_changed <= end)]
+        return {entity_ids[0]: selected}
+
+    sys.modules["homeassistant.components.history"] = SimpleNamespace(
+        get_significant_states=fake_history
+    )
+
+    import special_agent.tool_specs.get_entity_history as geh
+    importlib.reload(geh)
+
+    hass = MagicMock()
+    hass.async_add_executor_job = AsyncMock(
+        side_effect=lambda func, *a, **kw: func(*a, **kw)
+    )
+
+    start_iso = (base + timedelta(hours=1, minutes=30)).isoformat()
+    end_iso = (base + timedelta(hours=2, minutes=30)).isoformat()
+
+    result = asyncio.run(
+        geh.get_entity_history(
+            "sensor.test",
+            start_iso=start_iso,
+            end_iso=end_iso,
+            limit=10,
+            hass=hass,
+        )
+    )
+
+    assert all(
+        (base + timedelta(hours=1)) < datetime.fromisoformat(r["when"]) < (base + timedelta(hours=3))
+        for r in result
+    )
+

--- a/tool_specs/get_entity_history.py
+++ b/tool_specs/get_entity_history.py
@@ -1,0 +1,100 @@
+"""Return recent state changes for an entity from the recorder history."""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Dict, List
+
+import voluptuous as vol
+
+try:
+    import homeassistant.util.dt as dt_util
+    from homeassistant.util.dt import utcnow as utc_now
+    as_local = dt_util.as_local
+    parse_datetime = dt_util.parse_datetime
+except Exception:  # pragma: no cover - not available in unit test env
+    def utc_now() -> datetime:  # type: ignore
+        return datetime.utcnow()
+
+    class dt_util:  # type: ignore
+        @staticmethod
+        def as_local(dt: datetime) -> datetime:
+            return dt
+
+        @staticmethod
+        def parse_datetime(val: str) -> datetime:
+            return datetime.fromisoformat(val)
+
+    as_local = dt_util.as_local  # type: ignore
+    parse_datetime = dt_util.parse_datetime  # type: ignore
+
+from ..agent_core import ToolSpec
+from ..utils import logging as log
+
+try:  # allow import failure during tests
+    from homeassistant.components.history import get_significant_states
+except Exception:  # pragma: no cover - not available in unit test env
+    get_significant_states = None
+
+_LOGGER = logging.getLogger(__package__)
+
+MAX_EVENTS = 100
+
+PARAMS = vol.Schema(
+    {
+        vol.Required("entity_id"): str,
+        vol.Optional("lookback_hours", default=24): vol.All(
+            int, vol.Range(min=1, max=168)
+        ),
+        vol.Optional("start_iso"): str,
+        vol.Optional("end_iso"): str,
+        vol.Optional("target_state"): str,
+        vol.Optional("limit", default=1): vol.All(int, vol.Range(min=1)),
+    }
+)
+
+
+async def get_entity_history(
+    entity_id: str,
+    lookback_hours: int = 24,
+    start_iso: str | None = None,
+    end_iso: str | None = None,
+    target_state: str | None = None,
+    limit: int = 1,
+    hass: Any | None = None,
+) -> List[Dict[str, Any]]:
+    """Return a simplified list of state changes for an entity.
+
+    The Recorder history resets on Home Assistant restart. Results are capped
+    at ``MAX_EVENTS`` to avoid returning excessively large payloads.
+    """
+    if get_significant_states is None:
+        raise RuntimeError("history component not available")
+    if start_iso or end_iso:
+        start = parse_datetime(start_iso) if start_iso else None
+        end = parse_datetime(end_iso) if end_iso else None
+    else:
+        start = utc_now() - timedelta(hours=lookback_hours)
+        end = None
+    hist = await hass.async_add_executor_job(
+        get_significant_states, hass, start, end, [entity_id], True
+    )
+    events = hist.get(entity_id, [])
+    if target_state:
+        events = [e for e in events if e.state == target_state]
+    limit = min(limit, MAX_EVENTS)
+    events = events[-limit:]
+    result = [
+        {"state": e.state, "when": as_local(e.last_changed).isoformat()} for e in events
+    ]
+    log.debug("get_entity_history -> %s", result)
+    return result
+
+
+SPEC = ToolSpec(
+    name="get_entity_history",
+    description="Return recent state changes for entities.",
+    parameters=PARAMS,
+    returns="list of dict(state, when)",
+    func=get_entity_history,
+)

--- a/tool_specs/get_entity_state.py
+++ b/tool_specs/get_entity_state.py
@@ -1,0 +1,49 @@
+"""Return the live state and attributes for one or more entities."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+import voluptuous as vol
+
+from ..agent_core import ToolSpec
+from ..utils import logging as log
+
+_LOGGER = logging.getLogger(__package__)
+
+PARAMS = vol.Schema(
+    {
+        vol.Required("entity_ids"): vol.All([str], vol.Length(min=1)),
+        vol.Optional("attributes"): [str],
+    }
+)
+
+
+async def get_entity_state(
+    entity_ids: List[str],
+    attributes: List[str] | None = None,
+    hass: Any | None = None,
+) -> Dict[str, Any]:
+    """Return state and selected attributes for the given entities."""
+    result: Dict[str, Any] = {}
+    hass_states = getattr(hass, "states", None)
+    get_state = getattr(hass_states, "get", None) if hass_states else None
+    for eid in entity_ids:
+        state = get_state(eid) if callable(get_state) else None
+        if not state:
+            result[eid] = None
+            continue
+        attr_keys = attributes or list(state.attributes)
+        attrs = {k: state.attributes.get(k) for k in attr_keys if k in state.attributes}
+        result[eid] = {"state": state.state, **attrs}
+    log.debug("get_entity_state -> %s", result)
+    return result
+
+
+SPEC = ToolSpec(
+    name="get_entity_state",
+    description="Return current state and requested attributes for entities.",
+    parameters=PARAMS,
+    returns="dict of entity states",
+    func=get_entity_state,
+)


### PR DESCRIPTION
## Summary
- implement `get_entity_state` tool for state & attribute lookups
- implement `get_entity_history` tool for recent state changes
- load new tools in `Agent.load_tools`
- test new tools
- upgrade tools per review comments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68539f4676d4833283ea5bc3d6b9d16b