### PR TITLE
Improve entity tools

### DIFF
--- a/tests/test_entity_tools.py
+++ b/tests/test_entity_tools.py
@@ -32,6 +32,19 @@ def test_get_entity_state(monkeypatch):
     assert result["light.kitchen"]["brightness"] == 200
 
 
+def test_get_entity_state_accepts_string(monkeypatch):
+    from special_agent.tool_specs import get_entity_state as ges
+
+    state_obj = SimpleNamespace(state="on", attributes={"color": "blue"})
+    hass = MagicMock()
+    hass.states.get = MagicMock(return_value=state_obj)
+
+    result = asyncio.run(ges.get_entity_state("light.kitchen", hass=hass))
+
+    assert result["light.kitchen"]["state"] == "on"
+    assert "color" in result["light.kitchen"]
+
+
 def test_state_empty_list_fails():
     from special_agent.tool_specs import get_entity_state as ges
 
@@ -65,6 +78,33 @@ def test_get_entity_history(monkeypatch):
 
     assert result[0]["state"] == "on"
     assert "when" in result[0]
+
+
+def test_get_entity_history_accepts_list(monkeypatch):
+    events = [
+        SimpleNamespace(state="off", last_changed=datetime(2023, 1, 1, 12, 0)),
+        SimpleNamespace(state="on", last_changed=datetime(2023, 1, 1, 13, 0)),
+    ]
+
+    def fake_history(hass, start, end, entity_ids, significant):
+        return {entity_ids[0]: events}
+
+    history_mod = SimpleNamespace(get_significant_states=fake_history)
+    sys.modules["homeassistant.components.history"] = history_mod
+
+    import special_agent.tool_specs.get_entity_history as geh
+    importlib.reload(geh)
+
+    hass = MagicMock()
+    hass.async_add_executor_job = AsyncMock(
+        side_effect=lambda func, *a, **kw: func(*a, **kw)
+    )
+
+    result = asyncio.run(
+        geh.get_entity_history(["light.kitchen"], hass=hass, limit=1)
+    )
+
+    assert result[-1]["state"] == "on"
 
 
 def test_history_cap_applied(monkeypatch):

--- a/tool_specs/get_entity_history.py
+++ b/tool_specs/get_entity_history.py
@@ -40,9 +40,14 @@ _LOGGER = logging.getLogger(__package__)
 
 MAX_EVENTS = 100
 
+_ENTITY = vol.All(
+    vol.Any(str, [str]),
+    lambda v: v[0] if isinstance(v, list) else v,
+)
+
 PARAMS = vol.Schema(
     {
-        vol.Required("entity_id"): str,
+        vol.Required("entity_id"): _ENTITY,
         vol.Optional("lookback_hours", default=24): vol.All(
             int, vol.Range(min=1, max=168)
         ),
@@ -55,7 +60,7 @@ PARAMS = vol.Schema(
 
 
 async def get_entity_history(
-    entity_id: str,
+    entity_id: str | list[str],
     lookback_hours: int = 24,
     start_iso: str | None = None,
     end_iso: str | None = None,
@@ -70,6 +75,8 @@ async def get_entity_history(
     """
     if get_significant_states is None:
         raise RuntimeError("history component not available")
+    if isinstance(entity_id, list):
+        entity_id = entity_id[0]
     if start_iso or end_iso:
         start = parse_datetime(start_iso) if start_iso else None
         end = parse_datetime(end_iso) if end_iso else None
@@ -93,7 +100,11 @@ async def get_entity_history(
 
 SPEC = ToolSpec(
     name="get_entity_history",
-    description="Return recent state changes for entities.",
+    description=(
+        "Return recent state changes for an entity from recorder history. "
+        "'entity_id' may be a string or single-item list; a list is reduced "
+        "to its first value."
+    ),
     parameters=PARAMS,
     returns="list of dict(state, when)",
     func=get_entity_history,

--- a/tool_specs/get_entity_state.py
+++ b/tool_specs/get_entity_state.py
@@ -11,20 +11,23 @@ from ..utils import logging as log
 
 _LOGGER = logging.getLogger(__package__)
 
-PARAMS = vol.Schema(
-    {
-        vol.Required("entity_ids"): vol.All([str], vol.Length(min=1)),
-        vol.Optional("attributes"): [str],
-    }
+_ENTITIES = vol.All(
+    vol.Any(str, [str]),
+    lambda v: [v] if isinstance(v, str) else list(v),
+    vol.Length(min=1),
 )
+
+PARAMS = vol.Schema({vol.Required("entity_ids"): _ENTITIES, vol.Optional("attributes"): [str]})
 
 
 async def get_entity_state(
-    entity_ids: List[str],
+    entity_ids: List[str] | str,
     attributes: List[str] | None = None,
     hass: Any | None = None,
 ) -> Dict[str, Any]:
     """Return state and selected attributes for the given entities."""
+    if isinstance(entity_ids, str):
+        entity_ids = [entity_ids]
     result: Dict[str, Any] = {}
     hass_states = getattr(hass, "states", None)
     get_state = getattr(hass_states, "get", None) if hass_states else None
@@ -42,7 +45,11 @@ async def get_entity_state(
 
 SPEC = ToolSpec(
     name="get_entity_state",
-    description="Return current state and requested attributes for entities.",
+    description=(
+        "Return current state and requested attributes for entities. "
+        "Parameter 'entity_ids' accepts a single string or list of strings; "
+        "a single value will be wrapped into a list."
+    ),
     parameters=PARAMS,
     returns="dict of entity states",
     func=get_entity_state,


### PR DESCRIPTION
## Summary
- accept string or list for `get_entity_state` and `get_entity_history`
- clarify parameter expectations in both tool spec descriptions
- test that entity tools accept both string and list inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853bc73d9cc83328d88e5d7c75ed753