### PR TITLE
Clarify default attribute handling in get_entity_state

### DIFF
--- a/tests/test_entity_tools.py
+++ b/tests/test_entity_tools.py
@@ -45,6 +45,19 @@ def test_get_entity_state_accepts_string(monkeypatch):
     assert "color" in result["light.kitchen"]
 
 
+def test_get_entity_state_returns_all_attributes(monkeypatch):
+    from special_agent.tool_specs import get_entity_state as ges
+
+    attrs = {"color": "blue", "brightness": 100}
+    state_obj = SimpleNamespace(state="on", attributes=attrs)
+    hass = MagicMock()
+    hass.states.get = MagicMock(return_value=state_obj)
+
+    result = asyncio.run(ges.get_entity_state(["light.kitchen"], hass=hass))
+
+    assert result["light.kitchen"] == {"state": "on", **attrs}
+
+
 def test_state_empty_list_fails():
     from special_agent.tool_specs import get_entity_state as ges
 

--- a/tool_specs/get_entity_state.py
+++ b/tool_specs/get_entity_state.py
@@ -25,7 +25,11 @@ async def get_entity_state(
     attributes: List[str] | None = None,
     hass: Any | None = None,
 ) -> Dict[str, Any]:
-    """Return state and selected attributes for the given entities."""
+    """Return state and selected attributes for the given entities.
+
+    When ``attributes`` is ``None`` all available attributes from the
+    entity's state are returned.
+    """
     if isinstance(entity_ids, str):
         entity_ids = [entity_ids]
     result: Dict[str, Any] = {}


### PR DESCRIPTION
## Summary
- clarify that get_entity_state returns all attributes when none are provided
- add unit test verifying default behavior

## Testing
- `pytest tests/test_entity_tools.py::test_get_entity_state_returns_all_attributes -q`
- `pytest tests/test_entity_tools.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854ef49e98083328013e633ef291912