### PR TITLE
Add tool input/result debug logs

### DIFF
--- a/agent_core.py
+++ b/agent_core.py
@@ -396,9 +396,14 @@ async def plan_execute(
             log.debug("Action: %s %s", call_name, args)
             try:
                 if hass and "hass" in inspect.signature(spec.func).parameters:
-                    result = await spec.func(hass=hass, **args)
+                    call_args = {"hass": hass, **args}
+                    log.debug("Tool_Input[%s]: %s", call_name, call_args)
+                    result = await spec.func(**call_args)
                 else:
-                    result = await spec.func(**args)
+                    call_args = args
+                    log.debug("Tool_Input[%s]: %s", call_name, call_args)
+                    result = await spec.func(**call_args)
+                log.debug("Tool_Result[%s]: %s", call_name, result)
             except Exception as err:
                 log.error("Tool execution failed: %s", err)
                 messages.append(


### PR DESCRIPTION
## Summary
- capture tool input and output with `log.debug`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855000e7dec8332ab4fd5c30e43a102