### PR TITLE
Sanitize search_devices output

### DIFF
--- a/tests/test_search_device_filter.py
+++ b/tests/test_search_device_filter.py
@@ -9,7 +9,10 @@ def test_search_device_filter(tmp_path, monkeypatch):
         {
             "entity_id": "light.office_sconces",
             "name": "Office Sconces",
-            "attributes": {"friendly_name": "Office Sconces"},
+            "attributes": {
+                "friendly_name": "Office Sconces",
+                "brightness": 128,
+            },
             "domain": "light",
         },
         {
@@ -38,3 +41,10 @@ def test_search_device_filter(tmp_path, monkeypatch):
     ids = [r["entity_id"] for r in results]
     assert "light.office_sconces" in ids
     assert all("sensor.office_sconces_led_effect" != r for r in ids)
+
+    info = next(r["info"] for r in results if r["entity_id"] == "light.office_sconces")
+    attr_keys = next(r.get("attribute_keys") for r in results if r["entity_id"] == "light.office_sconces")
+    assert "128" not in info
+    assert "brightness" not in info and "friendly_name" not in info
+    assert info.endswith("Attributes:")
+    assert set(attr_keys) == {"friendly_name", "brightness"}

--- a/tool_specs/search_devices.py
+++ b/tool_specs/search_devices.py
@@ -1,9 +1,11 @@
-"""Tool for retrieving device entity_ids by filtered similarity search."""
+"""Tool for retrieving device metadata by filtered similarity search."""
 
 from __future__ import annotations
 
 import logging
-from typing import List, Any, Dict
+from typing import List, Any, Dict, Tuple
+
+import re
 
 import voluptuous as vol
 
@@ -16,6 +18,18 @@ from ..agent_core import ToolSpec
 from ..utils import logging as log
 
 _LOGGER = logging.getLogger(__package__)
+
+_ATTR_RE = re.compile(r'["\']([^"\']+)["\']\s*:')
+
+
+def _sanitize_info(text: str) -> Tuple[str, List[str] | None]:
+    """Strip attribute values and return key names only."""
+    if not text or "Attributes:" not in text:
+        return text or "", None
+    base, attr_str = text.split("Attributes:", 1)
+    keys = _ATTR_RE.findall(attr_str)
+    info = f"{base.strip()}\nAttributes:"
+    return info, keys if keys else None
 
 
 PARAMS = vol.Schema(
@@ -35,7 +49,7 @@ async def search_devices(
     k: int = 5,
     hass: Any | None = None,
 ) -> List[Dict[str, Any]]:
-    """Return matching devices with full metadata and text info."""
+    """Return matching devices with sanitized info and attribute keys."""
     k = min(k, MAX_SEARCH_K)
     index_data = await async_load_vector_index(hass=hass)
     filters: dict[str, Any] = {}
@@ -49,15 +63,17 @@ async def search_devices(
     results = []
     for doc in hits:
         meta = doc.get("metadata", {})
-        results.append(
-            {
-                "entity_id": meta.get("entity_id", ""),
-                "domain": meta.get("domain"),
-                "area_id": meta.get("area_id"),
-                "friendly_name": meta.get("friendly_name"),
-                "info": doc.get("page_content"),
-            }
-        )
+        info, attr_keys = _sanitize_info(doc.get("page_content", ""))
+        item = {
+            "entity_id": meta.get("entity_id", ""),
+            "domain": meta.get("domain"),
+            "area_id": meta.get("area_id"),
+            "friendly_name": meta.get("friendly_name"),
+            "info": info,
+        }
+        if attr_keys:
+            item["attribute_keys"] = attr_keys
+        results.append(item)
     return results
 
 
@@ -69,6 +85,6 @@ SPEC = ToolSpec(
         f"Parameter 'k' is capped at {MAX_SEARCH_K}."
     ),
     parameters=PARAMS,
-    returns="list of device info dicts",
+    returns="list of device info dicts with sanitized info and attribute_keys",
     func=search_devices,
 )


### PR DESCRIPTION
## Summary
- sanitize search_device results to strip attribute values
- extract attribute keys and expose via `attribute_keys`
- update docstrings and tests for sanitized output

## Testing
- `pytest tests/test_search_device_filter.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685504b2d3808332b3c1540a82471fd8