### PR TITLE
Add Plex search support for Plex playback

### DIFF
--- a/agent_core.py
+++ b/agent_core.py
@@ -59,6 +59,7 @@ class Agent:
             "tool_specs.ask_user",
             "tool_specs.search_devices",
             "tool_specs.control_device",
+            "tool_specs.search_plex",
             "tool_specs.search_spotify",
             "tool_specs.get_entity_state",
             "tool_specs.get_entity_history",

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,8 @@
         "openai",
         "langchain-community",
         "numpy",
-        "tiktoken"
+        "tiktoken",
+        "plexapi"
     ],
     "codeowners": ["@cliffmu"],
     "config_flow": true,

--- a/tool_specs/search_plex.py
+++ b/tool_specs/search_plex.py
@@ -37,7 +37,9 @@ SPEC = ToolSpec(
     name="search_plex_library",
     description=(
         "Search the connected Plex library and return rating keys for playback. "
-        "Use the 'ratingKey' with media_player.play_media (media_content_type='plex')."
+        "Use the 'ratingKey' with media_player.play_media (media_content_type='plex'). "
+        "Fire off additional searches (the tool can run in parallel) when you need to "
+        "check multiple title variations."
     ),
     parameters=PARAMS,
     returns="{hits: array}",

--- a/tool_specs/search_plex.py
+++ b/tool_specs/search_plex.py
@@ -1,0 +1,46 @@
+"""Search Plex for library items and return rating keys."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..agent_core import ToolSpec
+from ..utils.plex import plex_search as _plex_search
+from ..utils import logging as log
+
+PARAMS: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "query": {
+            "type": "string",
+            "description": "Search term to use against the Plex library",
+        },
+        "kind": {
+            "type": "string",
+            "enum": ["movie", "show", "episode"],
+            "description": "Optional Plex media type hint",
+        },
+    },
+    "required": ["query"],
+}
+
+
+async def search_plex(query: str, kind: str | None = None, hass: Any | None = None) -> Dict[str, Any]:
+    """Return Plex search hits."""
+
+    hits = await _plex_search(hass, query=query, kind=kind)
+    log.debug("search_plex: query=%s kind=%s hits=%d", query, kind, len(hits))
+    return {"hits": hits}
+
+
+SPEC = ToolSpec(
+    name="search_plex_library",
+    description=(
+        "Search the connected Plex library and return rating keys for playback. "
+        "Use the 'ratingKey' with media_player.play_media (media_content_type='plex')."
+    ),
+    parameters=PARAMS,
+    returns="{hits: array}",
+    func=search_plex,
+    can_run_parallel=True,
+)

--- a/utils/data_sources.py
+++ b/utils/data_sources.py
@@ -7,6 +7,11 @@ from collections import defaultdict
 from typing import Any, Dict, Iterable, List, Tuple
 
 try:  # Home Assistant may be absent during testing
+    from homeassistant.config_entries import ConfigEntry
+except ModuleNotFoundError:  # pragma: no cover - fallback stubs
+    ConfigEntry = Any  # type: ignore
+
+try:  # Home Assistant may be absent during testing
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers import area_registry as ar
     from homeassistant.helpers import device_registry as dr
@@ -161,3 +166,98 @@ async def get_devices_by_area(hass: HomeAssistant) -> Tuple[Dict, List[Dict]]:
     summary = {area: dict(domains) for area, domains in summary.items()}
     log.debug("get_devices_by_area: returning %d device details", len(detail))
     return summary, detail
+
+
+def get_integration_entry(hass: HomeAssistant, domain: str) -> ConfigEntry | None:
+    """Return the first config entry for ``domain`` if available."""
+
+    if hass is None:
+        log.debug("get_integration_entry: hass is None for domain=%s", domain)
+        return None
+
+    config_entries = getattr(hass, "config_entries", None)
+    if config_entries is None:
+        log.debug(
+            "get_integration_entry: hass has no config_entries attribute for domain=%s",
+            domain,
+        )
+        return None
+
+    try:
+        entries = config_entries.async_entries(domain)  # type: ignore[attr-defined]
+    except Exception as err:  # pragma: no cover - defensive
+        log.error(
+            "get_integration_entry: failed to fetch entries for domain=%s: %s",
+            domain,
+            err,
+        )
+        return None
+
+    if not entries:
+        log.debug("get_integration_entry: no entries for domain=%s", domain)
+        return None
+
+    entry = entries[0]
+    entry_id = getattr(entry, "entry_id", "unknown")
+    log.debug("get_integration_entry: using entry_id=%s for domain=%s", entry_id, domain)
+    return entry
+
+
+def get_plex_connection_info(hass: HomeAssistant) -> Tuple[str, str]:
+    """Return ``(base_url, token)`` required to connect to Plex."""
+
+    entry = get_integration_entry(hass, "plex")
+    if entry is None:
+        raise RuntimeError("Plex integration is not configured")
+
+    data: Dict[str, Any] = dict(getattr(entry, "data", {}) or {})
+    options: Dict[str, Any] = dict(getattr(entry, "options", {}) or {})
+
+    token = data.get("token") or options.get("token")
+    if not token:
+        raise RuntimeError("Plex token missing from config entry")
+
+    base_url = _extract_plex_base_url(data, options)
+    if not base_url:
+        raise RuntimeError("Plex base URL missing from config entry")
+
+    log.debug(
+        "get_plex_connection_info: resolved base_url for entry_id=%s",
+        getattr(entry, "entry_id", "unknown"),
+    )
+    return base_url, token
+
+
+def _extract_plex_base_url(data: Dict[str, Any], options: Dict[str, Any]) -> str | None:
+    """Best-effort extraction of the Plex server base URL."""
+
+    for key in ("base_url", "url"):
+        url = data.get(key) or options.get(key)
+        if isinstance(url, str) and url:
+            return url
+
+    server = data.get("server") or options.get("server")
+    if isinstance(server, dict):
+        for key in ("uri", "url", "baseurl", "base_url"):
+            url = server.get(key)
+            if isinstance(url, str) and url:
+                return url
+
+    host = data.get("host") or options.get("host")
+    if isinstance(host, str) and host:
+        ssl = bool(data.get("ssl") or options.get("ssl"))
+        port = (
+            data.get("port")
+            or options.get("port")
+            or (server.get("port") if isinstance(server, dict) else None)
+        )
+        try:
+            port_int = int(port) if port else None
+        except (TypeError, ValueError):
+            port_int = None
+        if not port_int:
+            port_int = 32400 if not ssl else 443
+        scheme = "https" if ssl or port_int == 443 else "http"
+        return f"{scheme}://{host}:{port_int}"
+
+    return None

--- a/utils/plex.py
+++ b/utils/plex.py
@@ -1,0 +1,161 @@
+"""Plex utilities."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+try:  # Home Assistant may be absent during testing
+    from homeassistant.core import HomeAssistant
+except ModuleNotFoundError:  # pragma: no cover - fallback stubs
+    HomeAssistant = Any  # type: ignore
+
+from . import logging as log
+from .data_sources import get_plex_connection_info
+
+_LOGGER = logging.getLogger(__package__)
+
+_SEASON_EPISODE_RE = re.compile(r"\bS(?P<season>\d{1,2})E(?P<episode>\d{1,2})\b", re.IGNORECASE)
+
+
+async def plex_search(
+    hass: HomeAssistant | None,
+    query: str,
+    kind: Optional[str] = None,
+    limit: int = 5,
+) -> List[Dict[str, Any]]:
+    """Search Plex for media matching ``query``."""
+
+    if not query:
+        log.debug("plex_search: empty query")
+        return []
+
+    if hass is None:
+        log.error("plex_search: hass instance is required")
+        return []
+
+    try:
+        base_url, token = get_plex_connection_info(hass)
+    except Exception as err:  # pragma: no cover - defensive
+        log.error("plex_search: unable to resolve Plex connection info: %s", err)
+        return []
+
+    log.debug(
+        "plex_search: query=%s kind=%s limit=%s base_url_resolved=%s",
+        query,
+        kind,
+        limit,
+        bool(base_url),
+    )
+
+    def _run_search() -> List[Dict[str, Any]]:
+        try:
+            from plexapi.exceptions import NotFound  # type: ignore
+            from plexapi.server import PlexServer  # type: ignore
+        except ModuleNotFoundError as exc:  # pragma: no cover - dependency missing
+            log.error("plex_search: plexapi not installed: %s", exc)
+            return []
+
+        try:
+            server = PlexServer(base_url, token)
+        except Exception as err:  # pragma: no cover - network issues
+            log.error("plex_search: failed to connect to Plex server: %s", err)
+            return []
+
+        machine_id = getattr(server, "machineIdentifier", None)
+        results: List[Any] = []
+
+        season_episode = _SEASON_EPISODE_RE.search(query)
+        cleaned_query = query
+        if season_episode:
+            cleaned_query = _SEASON_EPISODE_RE.sub("", query).strip()
+
+        try:
+            search_kwargs = {"limit": max(limit * 2, 10)}
+            if kind:
+                search_kwargs["mediatype"] = kind
+            results.extend(server.search(query, **search_kwargs))
+        except Exception as err:  # pragma: no cover - API errors
+            log.error("plex_search: search failed: %s", err)
+            return []
+
+        if season_episode:
+            try:
+                season = int(season_episode.group("season"))
+                episode = int(season_episode.group("episode"))
+            except (TypeError, ValueError):
+                season = episode = None
+
+            if season and episode:
+                try:
+                    shows = server.search(cleaned_query or query, mediatype="show")
+                except Exception as err:  # pragma: no cover - API errors
+                    log.error("plex_search: show lookup failed: %s", err)
+                    shows = []
+
+                for show in shows:
+                    try:
+                        ep = show.episode(season=season, episode=episode)
+                    except NotFound:
+                        continue
+                    except Exception as err:  # pragma: no cover - API errors
+                        log.error("plex_search: episode lookup failed: %s", err)
+                        continue
+                    if ep:
+                        results.insert(0, ep)
+                        break
+
+        seen_keys = set()
+        hits: List[Dict[str, Any]] = []
+
+        for item in results:
+            rating_key = getattr(item, "ratingKey", None)
+            if not rating_key or rating_key in seen_keys:
+                continue
+            seen_keys.add(rating_key)
+
+            media_type = getattr(item, "type", None) or getattr(item, "TYPE", None)
+            media_type = str(media_type) if media_type else None
+
+            hits.append(
+                {
+                    "title": getattr(item, "title", None),
+                    "type": media_type,
+                    "year": _safe_int(getattr(item, "year", None)),
+                    "ratingKey": str(rating_key),
+                    "grandparentTitle": getattr(item, "grandparentTitle", None),
+                    "season": _safe_int(
+                        getattr(item, "seasonNumber", None)
+                        or getattr(item, "parentIndex", None)
+                    ),
+                    "episode": _safe_int(
+                        getattr(item, "episodeNumber", None)
+                        or getattr(item, "index", None)
+                    ),
+                    "server_machineIdentifier": machine_id,
+                }
+            )
+
+            if len(hits) >= limit:
+                break
+
+        return hits
+
+    if hasattr(hass, "async_add_executor_job"):
+        try:
+            return await hass.async_add_executor_job(_run_search)
+        except Exception as err:  # pragma: no cover - defensive
+            log.error("plex_search: executor job failed: %s", err)
+            return []
+
+    return _run_search()
+
+
+def _safe_int(value: Any) -> Optional[int]:
+    try:
+        if value is None:
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/utils/plex.py
+++ b/utils/plex.py
@@ -87,7 +87,7 @@ async def plex_search(
             except (TypeError, ValueError):
                 season = episode = None
 
-            if season and episode:
+            if season is not None and episode is not None:
                 try:
                     shows = server.search(cleaned_query or query, mediatype="show")
                 except Exception as err:  # pragma: no cover - API errors


### PR DESCRIPTION
## Summary
- add helpers to retrieve integration config entries and Plex connection details
- implement a Plex search utility with episode parsing and expose it via a new tool spec
- register the Plex search tool with the agent and declare the plexapi dependency

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'voluptuous'; ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68e73971c6988332b0739a8c83775b16